### PR TITLE
Fix - handle Features with no images

### DIFF
--- a/src/lib/components/molecules/FeatureCard.svelte
+++ b/src/lib/components/molecules/FeatureCard.svelte
@@ -10,9 +10,11 @@
 	export let tags: TagType[] | undefined;
 </script>
 
-<Card additionalClass="feature-card">
+<Card additionalClass="feature-card {!image ? 'no-image' : ''}">
 	<div class="image" slot="image">
-		<Image src={image} alt="Picture describing the {name} feature" />
+		{#if image}
+			<Image src={image} alt="Picture describing the {name} feature" />
+		{/if}
 	</div>
 	<div class="content" slot="content">
 		<div class="title">
@@ -63,5 +65,9 @@
 
 	:global(.feature-card .image img) {
 		object-fit: cover;
+	}
+
+	:global(.feature-card.no-image > .image) {
+		display: none;
 	}
 </style>

--- a/src/lib/components/organisms/Footer.svelte
+++ b/src/lib/components/organisms/Footer.svelte
@@ -18,8 +18,9 @@
 		<div class="credits">
 			Powered by <a href="https://kit.svelte.dev/" target="_blank" rel="noopener noreferrer"
 				>SvelteKit</a
-			>. Icons by
-			<a href="https://iconoir.com/" target="_blank" rel="noopener noreferrer">Iconoir</a>.
+			>. Based on a template by
+			<a href="https://fantinel.dev/" target="_blank" rel="noopener noreferrer">Matheus Fantinel</a
+			>.
 		</div>
 		<div class="socials">
 			<Socials />

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import Header from '$lib/components/organisms/Header.svelte';
 	import Footer from '$lib/components/organisms/Footer.svelte';
 
@@ -11,7 +12,7 @@
 <main>
 	<div class="error-page">
 		<div class="container">
-			<h1>Oh no!</h1>
+			<h1>Oh no! {$page?.status ?? 'An error'}!</h1>
 			<div class="svg-wrapper">
 				<Error />
 			</div>


### PR DESCRIPTION
This PR also displays the error code in the error page (e.g. 404) and adds credit to the template developer in the Footer (that's me!).