### PR TITLE
Fix theme-color meta tag

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -35,8 +35,8 @@
 		<!-- Tell browser this site supports light and dark mode -->
 		<meta name="color-scheme" content="light dark" />
 		<!-- Color for browser url bar in mobile/Safari -->
-		<meta name="theme-color" media="(prefers-color-scheme: light)" content="#b28cf2" />
-		<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#4612A1" />
+		<meta name="theme-color" media="(prefers-color-scheme: light)" content="#F3D6CC" />
+		<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#53332C" />
 		<!-- Disable Google FLOC -->
 		<meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
 


### PR DESCRIPTION
Fixes #21 

Here's how it looks:

![Safari 2023-06-27 at 10 48 54](https://github.com/torrust/torrust-website/assets/24247035/c14b10f5-de55-4555-9644-3a79de719fbf)
