### PR TITLE
widen text on larger screens and change GmbH to SLU

### DIFF
--- a/src/lib/components/molecules/ContributorCard.svelte
+++ b/src/lib/components/molecules/ContributorCard.svelte
@@ -2,6 +2,7 @@
 	import Email from '$lib/icons/socials/email.svelte';
 	import Github from '$lib/icons/socials/github.svelte';
 	import Linkedin from '$lib/icons/socials/linkedin.svelte';
+	import Button from '$lib/components/atoms/Button.svelte';
 
 	export let name: string;
 	export let position: string | undefined = undefined;
@@ -42,7 +43,9 @@
 			<p>{@html para.para}</p>
 		{/each}
 	</div>
-	<a href="/contributors">Return to Contributors</a>
+	<Button>
+		<a href="/contributors" class="contributor-link">Return to Contributors</a>
+	</Button>
 </div>
 
 <style lang="scss">
@@ -53,9 +56,14 @@
 		text-align: center;
 		max-width: 600px;
 		margin: 0 auto;
-		margin-top: 2rem;
 		line-height: 1.5;
 		padding: 2rem;
+	}
+
+	@media screen and (min-width: 768px) {
+		.contributor-biography {
+			max-width: 1100px;
+		}
 	}
 
 	.cover-image {
@@ -65,7 +73,7 @@
 		box-shadow: var(--image-shadow);
 		border-radius: 6px;
 		box-shadow:
-			0 4px 8px 0 rgba(0, 0, 0, 0.2),
+			0 4px 8px 0 rgba(221, 209, 209, 0.2),
 			0 6px 20px 0 rgba(0, 0, 0, 0.19);
 	}
 
@@ -114,5 +122,10 @@
 		font-size: 1rem;
 		text-align: justify;
 		margin: 1rem 0;
+	}
+
+	.contributor-link {
+		font-weight: bolder;
+		color: #fff;
 	}
 </style>

--- a/src/lib/components/organisms/Footer.svelte
+++ b/src/lib/components/organisms/Footer.svelte
@@ -12,7 +12,7 @@
 	<div class="content">
 		<div class="copyright">
 			This project was a joint effort by <a href="https://nautilus-cyberneering.de/" target="_blank"
-				>Nautilus Cyberneering GmbH</a
+				>Nautilus Cyberneering SLU</a
 			>, <a href="https://dutchbits.nl/" target="_blank">Dutch Bits</a> and collaborators.
 		</div>
 		<div class="credits">

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -120,6 +120,7 @@
 		}
 
 		@include for-tablet-landscape-up {
+			--main-column-width: 100ch;
 			padding-right: 30px;
 			padding-left: 30px;
 		}


### PR DESCRIPTION
### Description:
* I have changed the widths of `blog articles` and `contributors` so that text spreads across more of the page on larger screens. 
* Edited the `Return to Contributors` button.
* Changed `Nautilus Cyberneering GmbH` to `Nautilus Cyberneering SLU` in the footer to reflect current state of the company.