### PR TITLE
add copy button to all code blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 			},
 			"devDependencies": {
 				"@histoire/plugin-svelte": "^0.16.1",
+				"@iconify/svelte": "^3.1.6",
 				"@sveltejs/adapter-static": "^2.0.1",
 				"@sveltejs/kit": "^1.22.4",
 				"@typescript-eslint/eslint-plugin": "^6.3.0",
@@ -665,6 +666,27 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
 			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+			"dev": true
+		},
+		"node_modules/@iconify/svelte": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-3.1.6.tgz",
+			"integrity": "sha512-yLSrlkOx5J6xXU5GDLPBV/MdVBVEZhd36onfqSbxQobp1XBoWQbMPLNZyCAmTKCPnmzXSowGy79agl8FQ3kj6A==",
+			"dev": true,
+			"dependencies": {
+				"@iconify/types": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyberalien"
+			},
+			"peerDependencies": {
+				"svelte": "*"
+			}
+		},
+		"node_modules/@iconify/types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/resolve-uri": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	},
 	"devDependencies": {
 		"@histoire/plugin-svelte": "^0.16.1",
+		"@iconify/svelte": "^3.1.6",
 		"@sveltejs/adapter-static": "^2.0.1",
 		"@sveltejs/kit": "^1.22.4",
 		"@typescript-eslint/eslint-plugin": "^6.3.0",

--- a/src/lib/components/atoms/CopyCodeButton.svelte
+++ b/src/lib/components/atoms/CopyCodeButton.svelte
@@ -1,0 +1,55 @@
+<script lang='ts'>
+    import Icon from '@iconify/svelte'
+    let copyButton: HTMLButtonElement
+    let showCheckmark = false
+
+    function handleClick(){
+        const preTagSibling = copyButton.nextElementSibling as HTMLPreElement
+
+        navigator.clipboard.writeText(preTagSibling.innerText)
+
+        showCheckmark = true
+
+        setTimeout(() => showCheckmark = false, 1000);
+    }
+</script>
+
+<button
+    on:click={handleClick}
+    bind:this={copyButton}
+    class={`copy-button ${showCheckmark ? 'copy-button-green' : 'copy-button-gray'}`}
+>
+    {#if showCheckmark}
+        <Icon icon="charm:tick" color="#6cdb2e" />
+    {:else}
+        <Icon icon="ion:copy-outline" color='#FFFFFF' />
+    {/if}
+</button>
+
+<style>
+    .copy-button {
+        position: absolute;
+        top: 1.5rem;
+        right: 1.5rem;
+        padding: 0.25rem;
+        border-radius: 0.375rem;
+        box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+        cursor: pointer;
+    }
+
+    .copy-button-green {
+        background-color: #047857;
+    }
+
+    .copy-button-green:hover {
+        background-color: #065f67;
+    }
+
+    .copy-button-gray {
+        background-color: #4a5568;
+    }
+
+    .copy-button-gray:hover {
+        background-color: #2d3748;
+    }
+</style>

--- a/src/lib/components/atoms/CopyCodeInjector.svelte
+++ b/src/lib/components/atoms/CopyCodeInjector.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import {onMount} from 'svelte'
+	import CopyCodeButton from './CopyCodeButton.svelte';
+
+    onMount(() => {
+		const preTags: HTMLCollectionOf<HTMLPreElement> = document.getElementsByTagName('pre')
+
+		for(let preTag of preTags){
+			const classList = Array.from(preTag.classList)
+
+			const isCodeBlock = classList.some((className) => className.startsWith('language'))
+
+			if(isCodeBlock){
+				const preTagParent = preTag.parentNode
+
+				const newCodeBlockWrapper = document.createElement('div')
+				newCodeBlockWrapper.className = 'relative'
+
+				new CopyCodeButton({
+					target: newCodeBlockWrapper
+				})
+
+				if(preTagParent){
+					preTagParent.replaceChild(newCodeBlockWrapper, preTag)
+					newCodeBlockWrapper.appendChild(preTag)
+				}
+			}
+		}
+	})
+</script>
+
+<slot />

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -8,6 +8,7 @@
 	import type { BlogPost } from '$lib/utils/types';
 	import RelatedPosts from '$lib/components/organisms/RelatedPosts.svelte';
 	import Image from '$lib/components/atoms/Image.svelte';
+	import CopyCodeInjector from '$lib/components/atoms/CopyCodeInjector.svelte';
 
 	export let data: { post: BlogPost };
 	$: ({ post } = data);
@@ -22,6 +23,8 @@
 			metaKeywords = post.keywords.concat(metaKeywords);
 		}
 	}
+
+	
 </script>
 
 <svelte:head>
@@ -46,7 +49,6 @@
 
 <div class="article-layout">
 	<Header showBackground />
-
 	<main>
 		<article id="article-content">
 			<div class="header">
@@ -79,7 +81,9 @@
 				</div>
 			{/if}
 			<div class="content">
-				<slot />
+				<CopyCodeInjector>
+					<slot />
+				</CopyCodeInjector>
 			</div>
 		</article>
 

--- a/src/routes/(blog-article)/deploying-torrust-to-production/+page.md
+++ b/src/routes/(blog-article)/deploying-torrust-to-production/+page.md
@@ -63,7 +63,7 @@ This tutorial is based on the Digital Ocean tutorial:
 
 [How To Secure a Containerized Node.js Application with Nginx, Let's Encrypt, and Docker Compose](https://www.digitalocean.com/community/tutorials/how-to-secure-a-containerized-node-js-application-with-nginx-let-s-encrypt-and-docker-compose).
 
-We have only changed the docker compose configuration and some steps to configure the __Torrust Index and Tracker__ instead of
+We have only changed the docker compose configuration and some steps to configure the **Torrust Index and Tracker** instead of
 the sample node application.
 
 After finishing this tutorial you will have these public services available (with your own domain):
@@ -86,10 +86,10 @@ We will explain how to install the required dependencies in the Ubuntu server.
 
 A Digital Ocean Droplet with a configuration similar to this:
 
-- __Datacenter__: Frankfurt (FRA1).
-- __Image__: Ubuntu 22.04 (LTS) x64.
-- __Droplet Type__: Shared CPU (Basic).
-- __CPU options__: Regular (Disk Type: SSD).
+- **Datacenter**: Frankfurt (FRA1).
+- **Image**: Ubuntu 22.04 (LTS) x64.
+- **Droplet Type**: Shared CPU (Basic).
+- **CPU options**: Regular (Disk Type: SSD).
 
 Resources:
 
@@ -282,10 +282,10 @@ You can execute queries to get the Tracker or Index data connecting with:
 <CodeBlock lang="bash">
 
 ```bash
-$ sqlite3 ./storage/index/lib/database/sqlite3.db 
+$ sqlite3 ./storage/index/lib/database/sqlite3.db
 SQLite version 3.37.2 2022-01-06 13:25:41
 Enter ".help" for usage hints.
-sqlite> 
+sqlite>
 ```
 
 </CodeBlock>
@@ -359,7 +359,7 @@ After cloning the repository you have to run the install script:
 <CodeBlock lang="bash">
 
 ```bash
-$ ./bin/install.sh 
+$ ./bin/install.sh
 Creating compose .env './.env'
 Creating proxy config file: './storage/proxy/etc/nginx-conf/nginx.conf'
 Creating index database: './storage/index/lib/database/sqlite3.db'
@@ -427,7 +427,7 @@ You can generate the secret token with:
 <CodeBlock lang="bash">
 
 ```bash
- gpg --armor --gen-random 1 40 
+ gpg --armor --gen-random 1 40
 jcrmbzlGyeP7z53TUQtXmtltMb5TubsIE9e0DPLnS4Ih29JddQw5JA==
 ```
 
@@ -436,7 +436,7 @@ jcrmbzlGyeP7z53TUQtXmtltMb5TubsIE9e0DPLnS4Ih29JddQw5JA==
 You also need to change the domain, change the Tracker API token and generate a secret token for the authentication in the Index configuration `storage/index/etc/index.toml`:
 
 ```toml
-... 
+...
 
 [tracker]
 url = "udp://tracker.torrust-demo.com:6969"
@@ -557,8 +557,8 @@ server
 
   ssl_certificate /etc/letsencrypt/live/index.torrust-demo.com-0001/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/index.torrust-demo.com-0001/privkey.pem;
-  
-  ssl_buffer_size 8k; 
+
+  ssl_buffer_size 8k;
 
   ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
 
@@ -715,7 +715,7 @@ We will use crontab to execute a command every day:
 <CodeBlock lang="bash">
 
 ```bash
-sudo crontab -e 
+sudo crontab -e
 ```
 
 </CodeBlock>
@@ -746,7 +746,7 @@ After generating the certificates and renewing them you should have a certbot di
 
 ```bash
 $ sudo tree storage/certbot/
-[sudo] password for torrust: 
+[sudo] password for torrust:
 storage/certbot/
 ├── etc
 │   ├── accounts
@@ -1069,12 +1069,12 @@ We used the health check endpoints for some services like APIs and the HTTP trac
 
 ## Cost
 
-- Basic droplet (1GB/1CPU, 25GB SSD Disk, 1000GB transfer): __$6__ per month.
-- Weekly droplet backup: __$1.20__ per month.
-- Reserved IP: __$5.00__ per month.
+- Basic droplet (1GB/1CPU, 25GB SSD Disk, 1000GB transfer): **$6** per month.
+- Weekly droplet backup: **$1.20** per month.
+- Reserved IP: **$5.00** per month.
 - Domain: depends on your provider.
 
-Total cost: __$12.2__ per month.
+Total cost: **$12.2** per month.
 
 See [Digital Ocean pricing](https://www.digitalocean.com/pricing) for more information.
 


### PR DESCRIPTION
## Pull Request: Added CopyCodeButton and CopyCodeInjector Components

### Changes Made
- Introduced a new SvelteKit component called `CopyCodeButton.svelte` for code block copy functionality.
- Refactored the logic by importing `CopyCodeButton` into a new component named `CopyCodeInjector.svelte`.
- Utilised the `onMount` lifecycle to dynamically wrap `pre` elements with the `CopyCodeButton` component if they represent code blocks.
- Integrated the `CopyCodeInjector` component into the `layout.svelte` file for the "blog-article" route, encapsulating the article's content slot.

### Details
- The `onMount` logic iterates through `pre` elements and checks if they represent code blocks based on the presence of a class starting with 'language'.
- When a code block is identified, a new `div` with the class `relative` is created, and the `CopyCodeButton` component is instantiated with this new div as the target.
- The `CopyCodeInjector` component is used in the layout to wrap around the article's content slot, providing code copy functionality.

### Additional Information
- Integrated Iconify for the icons on the copy code buttons.