### PR TITLE
Add share buttons at the top of each blog post

### DIFF
--- a/src/lib/components/atoms/ShareButton.svelte
+++ b/src/lib/components/atoms/ShareButton.svelte
@@ -1,24 +1,30 @@
 <script lang="ts">
     import Icon from '@iconify/svelte';
+    import { siteBaseUrl } from '$lib/data/meta';
+
     export let slug: string;
+    export let title: string;
+
+    const encodedSubject = encodeURIComponent("I wanted you to see this blog post");
+    const encodedSlug = encodeURIComponent(slug);
   
     const socialLinks = [
       {
         icon: "devicon:linkedin",
-        href: `http://www.linkedin.com/shareArticle?mini=true&url=https://torrust.com/${slug}`
+        href: `http://www.linkedin.com/shareArticle?mini=true&url=${siteBaseUrl}/${encodedSlug}`
       },
       {
         icon: "devicon:facebook",
-        href: `https://www.facebook.com/sharer.php?u=https://torrust.com/${slug}`
+        href: `https://www.facebook.com/sharer.php?u=${siteBaseUrl}/${encodedSlug}`
       },
       {
         icon: "ri:twitter-x-fill",
-        href: `https://twitter.com/share?url=https://torrust.com/${slug}`,
+        href: `https://twitter.com/share?url=${siteBaseUrl}/${encodedSlug}&text=${title}`,
         color: "#000000"
       },
       {
         icon: "ic:outline-mail",
-        href: `mailto:?subject=I wanted you to see this blog post&body=Check out this blog post https://torrust.com/${slug}`,
+        href: `mailto:?subject=${encodedSubject}&body='${title}' is a really interesting blog post from Torrust. Check it out here: ${siteBaseUrl}/${encodedSlug}`,
         color: "#1877f2"
       }
     ];

--- a/src/lib/components/atoms/ShareButton.svelte
+++ b/src/lib/components/atoms/ShareButton.svelte
@@ -6,9 +6,9 @@
     export let title: string;
 
     const encodedSubject = encodeURIComponent("I wanted you to see this blog post");
-    const encodedSlug = encodeURIComponent(slug);
     const encodedTitle = encodeURIComponent(title);
-    const encodedBody = encodeURIComponent(" is a really interesting blog post from Torrust. Check it out here: ");
+    const encodedBody = encodeURIComponent(`${title} is a really interesting blog post from Torrust. Check it out here: ${siteBaseUrl}/${slug}`)
+    const encodedSlug = encodeURIComponent(slug);
   
     const socialLinks = [
       {
@@ -26,7 +26,7 @@
       },
       {
         icon: "ic:outline-mail",
-        href: `mailto:?subject=${encodedSubject}&body=${encodedTitle}${encodedBody}${siteBaseUrl}/${encodedSlug}`,
+        href: `mailto:?subject=${encodedSubject}&body=${encodedBody}`,
         color: "#1877f2"
       }
     ];

--- a/src/lib/components/atoms/ShareButton.svelte
+++ b/src/lib/components/atoms/ShareButton.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+    import Icon from '@iconify/svelte';
+    export let slug: string;
+  
+    const socialLinks = [
+      {
+        icon: "devicon:linkedin",
+        href: `http://www.linkedin.com/shareArticle?mini=true&url=https://torrust.com/${slug}`
+      },
+      {
+        icon: "devicon:facebook",
+        href: `https://www.facebook.com/sharer.php?u=https://torrust.com/${slug}`
+      },
+      {
+        icon: "ri:twitter-x-fill",
+        href: `https://twitter.com/share?url=https://torrust.com/${slug}`,
+        color: "#000000"
+      },
+      {
+        icon: "ic:outline-mail",
+        href: `mailto:?subject=I wanted you to see this blog post&body=Check out this blog post https://torrust.com/${slug}`,
+        color: "#1877f2"
+      }
+    ];
+  </script>
+  
+<div class="link-container">
+    {#each socialLinks as { icon, href, color }}
+        <a {href} target="_blank" rel="noopener noreferrer">
+            <Icon {icon} width="30" height="30" {color} />
+        </a>
+    {/each}
+</div>
+  
+<style lang="scss">
+    .link-container {
+      display: flex;
+      gap: 1rem;
+    }
+</style>
+  

--- a/src/lib/components/atoms/ShareButton.svelte
+++ b/src/lib/components/atoms/ShareButton.svelte
@@ -7,6 +7,8 @@
 
     const encodedSubject = encodeURIComponent("I wanted you to see this blog post");
     const encodedSlug = encodeURIComponent(slug);
+    const encodedTitle = encodeURIComponent(title);
+    const encodedBody = encodeURIComponent(" is a really interesting blog post from Torrust. Check it out here: ");
   
     const socialLinks = [
       {
@@ -24,7 +26,7 @@
       },
       {
         icon: "ic:outline-mail",
-        href: `mailto:?subject=${encodedSubject}&body='${title}' is a really interesting blog post from Torrust. Check it out here: ${siteBaseUrl}/${encodedSlug}`,
+        href: `mailto:?subject=${encodedSubject}&body=${encodedTitle}${encodedBody}${siteBaseUrl}/${encodedSlug}`,
         color: "#1877f2"
       }
     ];

--- a/src/lib/components/atoms/ShareButton.svelte
+++ b/src/lib/components/atoms/ShareButton.svelte
@@ -9,6 +9,10 @@
     const encodedTitle = encodeURIComponent(title);
     const encodedBody = encodeURIComponent(`${title} is a really interesting blog post from Torrust. Check it out here: ${siteBaseUrl}/${slug}`)
     const encodedSlug = encodeURIComponent(slug);
+
+    const unescapedHref = (href: string) => {
+    	return href;
+    };
   
     const socialLinks = [
       {
@@ -34,7 +38,7 @@
   
 <div class="link-container">
     {#each socialLinks as { icon, href, color }}
-        <a {href} target="_blank" rel="noopener noreferrer">
+        <a href={unescapedHref(href)}  target="_blank" rel="noopener noreferrer">
             <Icon {icon} width="30" height="30" {color} />
         </a>
     {/each}

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -3,6 +3,7 @@
 	import Footer from '$lib/components/organisms/Footer.svelte';
 	import Tag from '$lib/components/atoms/Tag.svelte';
 	import { formatDate } from '$lib/utils/date';
+	import ShareButton from '$lib/components/atoms/ShareButton.svelte';
 
 	import { keywords, siteBaseUrl, title } from '$lib/data/meta';
 	import type { BlogPost } from '$lib/utils/types';
@@ -64,6 +65,7 @@
 							<span>By: </span><a href="/{post.contributorSlug}">{post.contributor}</a>
 						</div>
 					{/if}
+					<ShareButton slug={post.slug} />
 					{#if post.tags?.length}
 						<div class="tags">
 							{#each post.tags as tag}


### PR DESCRIPTION
## Summary

This pull request introduces a new SvelteKit component named `ShareButton.svelte`, designed to enable users to easily share blog articles on various social media platforms. Additionally, it integrates the new component into the existing `+layout.svelte` to provide users with sharing options for individual blog posts.

## Changes Made

### New Component: `ShareButton.svelte`
- The new component includes a list of social media links, each represented by an icon, allowing users to share the blog post on platforms such as LinkedIn, Facebook, Twitter, and via email.
- The component receives the `slug` of the blog post as a prop to generate the correct shareable URLs.

### Integration into `+layout.svelte`
- The `ShareButton` component has been integrated into the `+layout.svelte` file. This ensures that every individual blog post now includes social media sharing options.
- The `slug` is passed to the `ShareButton` component, making it specific to each blog post.