### PR TITLE
Make posts responsive on larger screens with SK components

### DIFF
--- a/src/lib/components/molecules/PostBody.svelte
+++ b/src/lib/components/molecules/PostBody.svelte
@@ -1,0 +1,9 @@
+<div>
+    <slot />
+</div>
+
+<style>
+    div{
+        grid-area: 1 / 3 / 6 / 7;
+    }
+</style>

--- a/src/lib/components/molecules/PostContainer.svelte
+++ b/src/lib/components/molecules/PostContainer.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+    let size: number;
+  </script>
+  
+  <svelte:window bind:innerWidth={size} />
+  
+  <div class="{size >= 1440 ? 'grid' : 'flex'}">
+    <slot />
+  </div>
+  
+  <style>
+      .grid {
+          display: grid;
+          grid-template-columns: repeat(6, 1fr);
+          grid-template-rows: repeat(5, 1fr);
+          grid-column-gap: 10px;
+          grid-row-gap: 0px;
+      }
+  
+      .flex {
+          display: flex;
+          flex-direction: column;
+      }
+  </style>
+  

--- a/src/lib/components/molecules/PostTable.svelte
+++ b/src/lib/components/molecules/PostTable.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+    import { onMount, afterUpdate } from 'svelte';
+  
+    let size: number;
+    let divStyle: string;
+  
+    const updateStyles = () => {
+      if (size >= 1440) {
+        divStyle = 'position: sticky; top: 0;';
+      } else {
+        divStyle = 'position: relative;';
+      }
+    };
+  
+    onMount(updateStyles);
+  
+    afterUpdate(updateStyles);
+  
+    $: {
+      updateStyles();
+    }
+  </script>
+  
+  <svelte:window bind:innerWidth={size} />
+  
+  <div class="{size >= 1440 ? 'scroll-container' : ''}" style="{divStyle}">
+    <div>
+      <slot />
+    </div>
+  </div>
+  
+  <style>
+    .scroll-container {
+      height: 100vh;
+      overflow-y: auto;
+    }
+  
+    div {
+      grid-area: 1 / 1 / 6 / 3;
+      background-color: transparent;
+      padding: 10px;
+    }
+  </style>
+  

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -65,7 +65,7 @@
 							<span>By: </span><a href="/{post.contributorSlug}">{post.contributor}</a>
 						</div>
 					{/if}
-					<ShareButton slug={post.slug} />
+					<ShareButton slug={post.slug} title={post.title} />
 					{#if post.tags?.length}
 						<div class="tags">
 							{#each post.tags as tag}
@@ -122,7 +122,7 @@
 		}
 
 		@include for-tablet-landscape-up {
-			--main-column-width: 100ch;
+			--main-column-width: 170ch;
 			padding-right: 30px;
 			padding-left: 30px;
 		}

--- a/src/routes/(blog-article)/containerizing-rust-applications-best-practices/+page.md
+++ b/src/routes/(blog-article)/containerizing-rust-applications-best-practices/+page.md
@@ -18,7 +18,13 @@ hidden: false
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
+
+<PostContainer>
+<PostTable>
 
 ## Table of Contents
 
@@ -42,6 +48,10 @@ hidden: false
 - [Other Considerations](#other-considerations)
 - [Links](links)
 - [Conclusion](#conclusion)
+
+</PostTable>
+
+<PostBody>
 
 ## Introduction
 
@@ -1048,3 +1058,6 @@ If you have any questions or issues please open an issue on the corresponding re
 - Containerizing Rust Applications Examples: <https://github.com/torrust/containerizing-rust-apps-examples>
 
 We very welcome any contributions to the projects or [this article](https://github.com/torrust/torrust-website/issues).
+
+</PostBody>
+</PostContainer>

--- a/src/routes/(blog-article)/deploying-torrust-to-production/+page.md
+++ b/src/routes/(blog-article)/deploying-torrust-to-production/+page.md
@@ -17,7 +17,13 @@ hidden: false
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
+
+<PostContainer>
+<PostTable>
 
 ## Table of Contents
 
@@ -46,6 +52,10 @@ hidden: false
 - [Links](links)
 - [Conclusion](#conclusion)
 
+</PostTable>
+
+<PostBody>
+
 ## Introduction
 
 Welcome to our guide on deploying a BitTorrent Index and Tracker. We'll walk you through each step, explaining the process in a user-friendly manner, so you can understand the magic behind hosting a powerful, Rust-based application on the cloud.
@@ -63,7 +73,7 @@ This tutorial is based on the Digital Ocean tutorial:
 
 [How To Secure a Containerized Node.js Application with Nginx, Let's Encrypt, and Docker Compose](https://www.digitalocean.com/community/tutorials/how-to-secure-a-containerized-node-js-application-with-nginx-let-s-encrypt-and-docker-compose).
 
-We have only changed the docker compose configuration and some steps to configure the __Torrust Index and Tracker__ instead of
+We have only changed the docker compose configuration and some steps to configure the **Torrust Index and Tracker** instead of
 the sample node application.
 
 After finishing this tutorial you will have these public services available (with your own domain):
@@ -86,10 +96,10 @@ We will explain how to install the required dependencies in the Ubuntu server.
 
 A Digital Ocean Droplet with a configuration similar to this:
 
-- __Datacenter__: Frankfurt (FRA1).
-- __Image__: Ubuntu 22.04 (LTS) x64.
-- __Droplet Type__: Shared CPU (Basic).
-- __CPU options__: Regular (Disk Type: SSD).
+- **Datacenter**: Frankfurt (FRA1).
+- **Image**: Ubuntu 22.04 (LTS) x64.
+- **Droplet Type**: Shared CPU (Basic).
+- **CPU options**: Regular (Disk Type: SSD).
 
 Resources:
 
@@ -282,10 +292,10 @@ You can execute queries to get the Tracker or Index data connecting with:
 <CodeBlock lang="bash">
 
 ```bash
-$ sqlite3 ./storage/index/lib/database/sqlite3.db 
+$ sqlite3 ./storage/index/lib/database/sqlite3.db
 SQLite version 3.37.2 2022-01-06 13:25:41
 Enter ".help" for usage hints.
-sqlite> 
+sqlite>
 ```
 
 </CodeBlock>
@@ -359,7 +369,7 @@ After cloning the repository you have to run the install script:
 <CodeBlock lang="bash">
 
 ```bash
-$ ./bin/install.sh 
+$ ./bin/install.sh
 Creating compose .env './.env'
 Creating proxy config file: './storage/proxy/etc/nginx-conf/nginx.conf'
 Creating index database: './storage/index/lib/database/sqlite3.db'
@@ -427,7 +437,7 @@ You can generate the secret token with:
 <CodeBlock lang="bash">
 
 ```bash
- gpg --armor --gen-random 1 40 
+ gpg --armor --gen-random 1 40
 jcrmbzlGyeP7z53TUQtXmtltMb5TubsIE9e0DPLnS4Ih29JddQw5JA==
 ```
 
@@ -436,7 +446,7 @@ jcrmbzlGyeP7z53TUQtXmtltMb5TubsIE9e0DPLnS4Ih29JddQw5JA==
 You also need to change the domain, change the Tracker API token and generate a secret token for the authentication in the Index configuration `storage/index/etc/index.toml`:
 
 ```toml
-... 
+...
 
 [tracker]
 url = "udp://tracker.torrust-demo.com:6969"
@@ -557,8 +567,8 @@ server
 
   ssl_certificate /etc/letsencrypt/live/index.torrust-demo.com-0001/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/index.torrust-demo.com-0001/privkey.pem;
-  
-  ssl_buffer_size 8k; 
+
+  ssl_buffer_size 8k;
 
   ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
 
@@ -715,7 +725,7 @@ We will use crontab to execute a command every day:
 <CodeBlock lang="bash">
 
 ```bash
-sudo crontab -e 
+sudo crontab -e
 ```
 
 </CodeBlock>
@@ -746,7 +756,7 @@ After generating the certificates and renewing them you should have a certbot di
 
 ```bash
 $ sudo tree storage/certbot/
-[sudo] password for torrust: 
+[sudo] password for torrust:
 storage/certbot/
 ├── etc
 │   ├── accounts
@@ -1069,12 +1079,12 @@ We used the health check endpoints for some services like APIs and the HTTP trac
 
 ## Cost
 
-- Basic droplet (1GB/1CPU, 25GB SSD Disk, 1000GB transfer): __$6__ per month.
-- Weekly droplet backup: __$1.20__ per month.
-- Reserved IP: __$5.00__ per month.
+- Basic droplet (1GB/1CPU, 25GB SSD Disk, 1000GB transfer): **$6** per month.
+- Weekly droplet backup: **$1.20** per month.
+- Reserved IP: **$5.00** per month.
 - Domain: depends on your provider.
 
-Total cost: __$12.2__ per month.
+Total cost: **$12.2** per month.
 
 See [Digital Ocean pricing](https://www.digitalocean.com/pricing) for more information.
 
@@ -1158,3 +1168,6 @@ If you have any questions or issues please open an issue in the corresponding re
 - Containerizing Rust Applications Examples: <https://github.com/torrust/containerizing-rust-apps-examples>
 
 We very welcome any contributions to the projects or [this article](https://github.com/torrust/torrust-website/issues).
+
+</PostBody>
+</PostContainer>

--- a/src/routes/(blog-article)/how-to-contribute-to-this-site/+page.md
+++ b/src/routes/(blog-article)/how-to-contribute-to-this-site/+page.md
@@ -13,12 +13,24 @@ hidden: false
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
+
+<PostContainer>
+<PostTable>
+
+## Table of Contents
 
 - [Processing](#processing)
 - [Creating a new post](#creating-a-new-post)
 - [Managing blog posts](#managing-blog-posts)
 - [RSS](#rss)
+
+</PostTable>
+
+<PostBody>
 
 All blog posts are located inside the `src/routes/(blog-article)` folder. Each folder inside it represents a blog post, and each folder has a `+page.md` file, which is the file that contains the post's content.
 
@@ -71,3 +83,6 @@ I highly recommend the [Front Matter VS Code extension](https://frontmatter.code
 ## RSS
 
 This template automatically generates a RSS feed of your blog posts. It is generated in the `src/routes/rss.xml/+server.ts` file, and it is available at the `/rss.xml` URL.
+
+</PostBody>
+</PostContainer>

--- a/src/routes/(blog-article)/how-to-run-a-local-demo/+page.md
+++ b/src/routes/(blog-article)/how-to-run-a-local-demo/+page.md
@@ -18,13 +18,25 @@ updated: 2023-07-11T15:28:29.783Z
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
+
+<PostContainer>
+<PostTable>
+
+## Table of Contents
 
 - [Requirements](#requirements)
 - [Running the demo](#running-the-demo)
 - [Application Setup](#application-setup)
 - [Advanced Setup](#advanced-setup)
 - [Conclusion](#conclusion)
+
+</PostTable>
+
+<PostBody>
 
 If you want to try the Torrust Index **demo** on your computer, you can easily run it with Git and Docker. This guide will explain how to setup the demo on your own computer in **a few seconds**.
 
@@ -139,3 +151,6 @@ If you have any questions or issues please open an issue on the corresponding re
 - Torrust Index Frontend: <https://github.com/torrust/torrust-index-frontend/issues>
 
 We very welcome any contributions to the project!
+
+</PostBody>
+</PostContainer>

--- a/src/routes/(blog-article)/how-to-setup-the-development-environment/+page.md
+++ b/src/routes/(blog-article)/how-to-setup-the-development-environment/+page.md
@@ -19,7 +19,15 @@ hidden: false
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
+
+<PostContainer>
+<PostTable>
+
+## Table of Contents
 
 - [Introduction](#introduction)
 - [Common Dependencies](#common-dependencies)
@@ -29,6 +37,10 @@ hidden: false
 - [Application Setup](#application-setup)
 - [Development tools](#development-tools)
 - [Conclusion](#conclusion)
+
+</PostTable>
+
+<PostBody>
 
 ## Introduction
 
@@ -306,3 +318,6 @@ If you have any questions or issues please open an issue on the corresponding re
 - Torrust Index Frontend: <https://github.com/torrust/torrust-index-frontend/issues>
 
 We very welcome any contributions to the project!
+
+</PostBody>
+</PostContainer>

--- a/src/routes/(blog-article)/introducing-the-new-sample-torrent-migration-tool/+page.md
+++ b/src/routes/(blog-article)/introducing-the-new-sample-torrent-migration-tool/+page.md
@@ -17,6 +17,9 @@ updated: 2023-09-04T13:24:27.241Z
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
 
 Photo by David Dibert: <https://www.pexels.com/photo/a-flock-of-geese-flying-7177008/>.
@@ -25,6 +28,9 @@ Hello, Torrust community!
 
 We're always looking for ways to enhance your experience with Torrust, and today, we're excited to unveil our latest addition: [A sample migration tool written in Rust](https://github.com/torrust/torrents-importer-sample), specifically designed for those looking to seamlessly import torrents from other sources into our [Torrust Index](https://github.com/torrust/torrust-index-backend)!
 
+<PostContainer>
+<PostTable>
+
 ## Table of contents
 
 - [Why this tool?](#why-this-tool)
@@ -32,6 +38,10 @@ We're always looking for ways to enhance your experience with Torrust, and today
 - [Conclusion](#conclusion)
 - [Links](#links)
 - [Acknowledgments](#acknowledgments)
+
+</PostTable>
+
+<PostBody>
 
 ## Why this tool?
 
@@ -129,3 +139,6 @@ For any other questions or issues related to Torrust repositories, please open a
 - Torrust Index Frontend: <https://github.com/torrust/torrust-index-frontend/issues>
 
 We very welcome any contributions to the project!
+
+</PostBody>
+</PostContainer>

--- a/src/routes/(blog-article)/live-demo-beta-v3/+page.md
+++ b/src/routes/(blog-article)/live-demo-beta-v3/+page.md
@@ -16,9 +16,29 @@ hidden: false
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
 
-**Hello, Torrent Enthusiasts!**
+<PostContainer>
+<PostTable>
+
+## Table of contents
+
+- [Hello, Torrent Enthusiasts!](#hello-torrent-enthusiasts)
+- [Experience the Beta Demo Today](#experience-the-beta-demo-today)
+- [Your Feedback Makes Us Better](#your-feedback-makes-us-better)
+- [Join the Conversation](#join-the-conversation)
+- [Important Notice: Demo Availability](#important-notice-demo-availability)
+- [A Heartfelt Thank You to Our Contributors](#a-heartfelt-thank-you-to-our-contributors)
+- [Join Us in This Exciting Journey](#join-us-in-this-exciting-journey)
+
+</PostTable>
+
+<PostBody>
+
+## **Hello, Torrent Enthusiasts!**
 
 We're thrilled to announce the beta demo of Bittorrent Torrust Index v3.0.0 is now live! This is a significant milestone for us, and we're eager to share what we've been working on with our vibrant community.
 
@@ -59,3 +79,6 @@ This release wouldn't have been possible without the dedication and hard work of
 ## Join Us in This Exciting Journey
 
 We're just getting started, and there's much more to come. Stay tuned for more updates, and thank you for being a part of this journey. We very welcome any contributions to the projects.
+
+</PostBody>
+</PostContainer>

--- a/src/routes/(blog-article)/the-enigmatic-torrent-source-field/+page.md
+++ b/src/routes/(blog-article)/the-enigmatic-torrent-source-field/+page.md
@@ -17,9 +17,15 @@ updated: 2023-08-08T13:56:28.769Z
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
 
 The BitTorrent protocol, despite its widespread usage, has often been met with raised eyebrows by the tech community due to its sometimes vague or entirely missing documentation. Today, we'll dive into one such mystery: the "source" field located within the "info" part of torrent files.
+
+<PostContainer>
+<PostTable>
 
 ## Table of contents
 
@@ -31,6 +37,10 @@ The BitTorrent protocol, despite its widespread usage, has often been met with r
 - [Links](#links)
 - [Acknowledgments](#acknowledgments)
 - [Conclusion](#conclusion)
+
+</PostTable>
+
+<PostBody>
 
 <Callout type="info">
 
@@ -219,3 +229,6 @@ For any other questions or issues related to Torrust repositories, please open a
 - Torrust Index Frontend: <https://github.com/torrust/torrust-index-frontend/issues>
 
 We very welcome any contributions to the project!
+
+</PostBody>
+</PostContainer>

--- a/src/routes/(blog-article)/what-is-a-bittorrent-tracker/+page.md
+++ b/src/routes/(blog-article)/what-is-a-bittorrent-tracker/+page.md
@@ -21,15 +21,27 @@ description: Basic explanation of  what a BitTorrent tracker is and the two type
   import Callout from "$lib/components/molecules/Callout.svelte";
   import CodeBlock from "$lib/components/molecules/CodeBlock.svelte";
   import Image from "$lib/components/atoms/Image.svelte";
+  import PostBody from "$lib/components/molecules/PostBody.svelte";
+  import PostContainer from "$lib/components/molecules/PostContainer.svelte";
+  import PostTable from "$lib/components/molecules/PostTable.svelte";
 </script>
 
 Photo by Alex Andrews: <https://www.pexels.com/photo/shallow-focus-photography-of-black-and-silver-compasses-on-top-of-map-1203808/>.
+
+<PostContainer>
+<PostTable>
+
+## Table of Contents
 
 - [Introduction](#introduction)
 - [What is a BitTorrent Tracker](#what-is-a-bittorrent-tracker)
 - [Public trackers](#public-trackers)
 - [Private trackers](#private-trackers)
 - [BitTorrent Index vs BitTorrent Tracker](#bittorrent-index-vs-bittorrent-tracker)
+
+</PostTable>
+
+<PostBody>
 
 ## Introduction
 
@@ -100,3 +112,6 @@ For any other questions or issues related to Torrust repositories, please open a
 - Torrust Index Frontend: <https://github.com/torrust/torrust-index-frontend/issues>
 
 We very welcome any contributions to the project!
+
+</PostBody>
+</PostContainer>


### PR DESCRIPTION
In this pull request, I've introduced three SvelteKit components:

## 1. PostBody.svelte:
* This component wraps the body of the blog post and defines its grid area for proper placement.

## 2. PostTable.svelte:
* Wraps the table of contents.
* Utilises Svelte's lifecycle methods to determine the screen size and adjust styles accordingly.
* Implements sticky positioning for the table of contents on larger screens.
* The table of contents remains static during scrolling but can scroll if its content exceeds the screen height.

## 3. PostContainer.svelte:
* Wraps both `PostBody` and `PostTable` components.
* Adjusts its layout based on screen width - displaying as a grid on larger screens and as a column on smaller screens.
* These components collectively enhance the responsiveness and layout of our blog posts, ensuring a better user experience across various devices.

Also, fixed bug in `+layout.svelte` of `(blog-article)` where `title={post.title}` wasn't being passed to the `ShareButton` component