### PR TITLE
Add strap linking to GitHub repo on a timeout unless hovered over

### DIFF
--- a/src/lib/components/atoms/Strap.svelte
+++ b/src/lib/components/atoms/Strap.svelte
@@ -34,7 +34,7 @@
     <div class="hover-strap" on:mouseover={() => clearInterval(hoverStrapTimeout)} on:focus>
         <div class="progress-bar" style="width: {progressBarWidth}%"></div>
         <div class="github-div">
-            Watch our <a href="https://github.com/torrust" target="_blank" rel="noopener noreferrer">GitHub repo</a> to stay up to date
+            Watch our <a href="https://github.com/torrust" target="_blank" rel="noopener noreferrer">GitHub repos</a> to stay up to date
         </div>
     </div>
 {/if}

--- a/src/lib/components/atoms/Strap.svelte
+++ b/src/lib/components/atoms/Strap.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+    import {onMount, onDestroy} from 'svelte'
+
+    let showHoverStrap = true
+    let hoverStrapTimeout: any
+    let progressBarWidth = 100
+
+    function hideHoverStrap(){
+        showHoverStrap = false
+    }
+
+    onMount(() => {
+        const duration = 10000
+        const interval = 100
+        let elapsed = 0
+
+        hoverStrapTimeout = setInterval(() => {
+            elapsed += interval
+            progressBarWidth = ((duration - elapsed) / duration) * 100
+
+            if(elapsed >= duration){
+                clearInterval(hoverStrapTimeout)
+                hideHoverStrap()
+            }
+        }, interval)
+    })
+
+    onDestroy(() => {
+        clearInterval(hoverStrapTimeout)
+    })
+</script>
+
+{#if showHoverStrap}
+    <div class="hover-strap" on:mouseover={() => clearInterval(hoverStrapTimeout)} on:focus>
+        <div class="progress-bar" style="width: {progressBarWidth}%"></div>
+        <div class="github-div">
+            Watch our <a href="https://github.com/torrust/torrust-tracker" target="_blank" rel="noopener noreferrer">GitHub repo</a> to stay up to date
+        </div>
+    </div>
+{/if}
+
+<style>
+    .hover-strap {
+        position: relative;
+        top: 0;
+        left: 0;
+        width: 100%;
+        padding: .3rem;
+        background: transparent;
+        color: #000;
+        text-align: center;
+        cursor: pointer;
+        z-index: 1001;
+        overflow: hidden;
+        transition: opacity 0.5s ease-in-out;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        
+    }
+
+    .progress-bar {
+        height: 5px;
+        background: rgba(248, 181, 153, 1);
+        transition: width 100ms linear;
+        border-radius: 10px;
+    }
+
+    .github-div{
+        cursor: default;
+    }
+</style>

--- a/src/lib/components/atoms/Strap.svelte
+++ b/src/lib/components/atoms/Strap.svelte
@@ -34,7 +34,7 @@
     <div class="hover-strap" on:mouseover={() => clearInterval(hoverStrapTimeout)} on:focus>
         <div class="progress-bar" style="width: {progressBarWidth}%"></div>
         <div class="github-div">
-            Watch our <a href="https://github.com/torrust/torrust-tracker" target="_blank" rel="noopener noreferrer">GitHub repo</a> to stay up to date
+            Watch our <a href="https://github.com/torrust" target="_blank" rel="noopener noreferrer">GitHub repo</a> to stay up to date
         </div>
     </div>
 {/if}

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -2,8 +2,11 @@
 	import Logo from '$lib/components/atoms/Logo.svelte';
 	import ThemeToggle from '$lib/components/molecules/ThemeToggle.svelte';
 	import RssLink from '$lib/components/atoms/RssLink.svelte';
-	import Socials from '../molecules/Socials.svelte';
-	import AnimatedHamburger from '../atoms/AnimatedHamburger.svelte';
+	import Socials from '$lib/components/molecules/Socials.svelte';
+	import AnimatedHamburger from '$lib/components/atoms/AnimatedHamburger.svelte';
+	import Strap from '$lib/components/atoms/Strap.svelte'
+	import {page} from '$app/stores'
+	import {onMount} from 'svelte'
 
 	export let showBackground = false;
 
@@ -16,9 +19,23 @@
 	function closeMenu() {
 		isMenuOpen = false;
 	}
+
+	let showHoverStrap = true
+	let hoverStrapTimeout: any
+
+	function hideHoverStrap(){
+		showHoverStrap = false
+	}
+
+	onMount(() => {
+		hoverStrapTimeout = setTimeout(hideHoverStrap, 10000);
+	})
 </script>
 
 <header class:has-background={showBackground}>
+	{#if $page.url.pathname === '/'}
+		<Strap />
+	{/if}
 	<div class="navbar">
 		<a class="logo" href="/" aria-label="Site logo">
 			<Logo />
@@ -26,9 +43,6 @@
 		<AnimatedHamburger {isMenuOpen} {toggleMenu}>
 			<div class="links-wrapper">
 				<ul class="links">
-					<li>
-						<a href="/blog" on:click={closeMenu}>Blog</a>
-					</li>
 					<li>
 						<button on:click={closeMenu}>
 							<Socials />


### PR DESCRIPTION
I've added a new SvelteKit component, called `Strap`, to enhance the homepage by displaying a link to the Torrust GitHub repository at the top of the home page. The purpose is to make this link visible for a limited time, encouraging users to explore our repository, but also going away if they aren't currently interested.

## Strap Component Highlights:
- Display Logic: The `Strap` component includes logic to display the GitHub link for 10 seconds. Hovering over the component stops the timer.
- Integration in Header Component: The `Strap` component is integrated into the `Header` component and is conditionally rendered on the homepage.

## How to Spot the Changes:
- In `Strap.svelte`, you'll find the logic for the timed display and the associated HTML and CSS.
- In `Header.svelte`, the integration of the `Strap` component is wrapped within a conditional check for the homepage.

## Why this Change?
This enhancement is aimed at increasing visibility and encouraging engagement with our GitHub repository. The `Strap` component adds a subtle yet effective call-to-action on the homepage.