### PR TITLE
Add button for live demo to Hero section

### DIFF
--- a/src/lib/components/organisms/Hero.svelte
+++ b/src/lib/components/organisms/Hero.svelte
@@ -2,6 +2,7 @@
 	import FeaturesIcon from '$lib/icons/features.svelte';
 	import BlogIcon from '$lib/icons/blog.svelte';
 	import Button from '$lib/components/atoms/Button.svelte';
+	import Icon from '@iconify/svelte';
 
 	export let hasFeatures: boolean;
 	export let hasPosts: boolean;
@@ -27,6 +28,12 @@
 				Get Started
 			</Button>
 		{/if}
+		<Button href="http://index.torrust-demo.com">
+			<span>
+				<Icon icon="formkit:arrowright" color="white" />
+			</span>
+			Live Demo
+		</Button>
 	</div>
 </section>
 

--- a/src/lib/components/organisms/Hero.svelte
+++ b/src/lib/components/organisms/Hero.svelte
@@ -28,7 +28,7 @@
 				Get Started
 			</Button>
 		{/if}
-		<Button href="http://index.torrust-demo.com">
+		<Button href="https://index.torrust-demo.com">
 			<span>
 				<Icon icon="formkit:arrowright" color="white" />
 			</span>


### PR DESCRIPTION
## Description
This pull request introduces a "Live Demo" button to the Hero section of the page. The button is linked to the Bittorrent Torrust Index [live demo](http://index.torrust-demo.com/).

## Context
The "Live Demo" button enhances the user experience by providing quick access to the Torrust live demo, encouraging users to explore the platform's features directly from the Hero section. It also adds design balance to the page.

This PR addresses issue [#135](https://github.com/torrust/torrust-website/issues/135)