### PR TITLE
Add tooltip to GitHub icon in header to encourage the user to follow GitHub

### DIFF
--- a/src/lib/components/atoms/Tooltip.svelte
+++ b/src/lib/components/atoms/Tooltip.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+    export let text: string = ''
+</script>
+
+<div class="tooltip">
+    <slot />
+    <div class="tooltiptext">
+        {text}
+    </div>
+</div>
+
+<style>
+    .tooltip {
+        position: relative;
+        display: inline-block;
+        cursor: pointer;
+    }
+  
+    .tooltip .tooltiptext {
+        visibility: hidden;
+        width: 200px;
+        background-color: #555;
+        color: #fff;
+        text-align: center;
+        border-radius: 6px;
+        padding: 5px;
+        position: absolute;
+        z-index: 1;
+        top: 100%;
+        left: 50%;
+        margin-left: -100px;
+        opacity: 0;
+        transition: opacity 0.3s;
+        font-size: .8rem;
+    }
+  
+    .tooltip:hover .tooltiptext {
+        visibility: visible;
+        opacity: 1;
+    }
+
+    @media (max-width: 767px) {
+		.tooltip:hover .tooltiptext {
+			opacity: 0; /* Set opacity to 0 for smaller screens when tooltip is hovered */
+		}
+	}
+</style>

--- a/src/lib/components/molecules/Socials.svelte
+++ b/src/lib/components/molecules/Socials.svelte
@@ -4,10 +4,9 @@
 
 <div class="socials">
 	<a
-		href="https://github.com/torrust/torrust-website"
+		href="https://github.com/torrust"
 		target="_blank"
 		rel="noopener noreferrer"
-		title="See source code on GitHub"
 	>
 		<GitHubIcon />
 	</a>

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -4,9 +4,7 @@
 	import RssLink from '$lib/components/atoms/RssLink.svelte';
 	import Socials from '$lib/components/molecules/Socials.svelte';
 	import AnimatedHamburger from '$lib/components/atoms/AnimatedHamburger.svelte';
-	import Strap from '$lib/components/atoms/Strap.svelte'
-	import {page} from '$app/stores'
-	import {onMount} from 'svelte'
+	import Tooltip from '$lib/components/atoms/Tooltip.svelte';
 
 	export let showBackground = false;
 
@@ -19,23 +17,9 @@
 	function closeMenu() {
 		isMenuOpen = false;
 	}
-
-	let showHoverStrap = true
-	let hoverStrapTimeout: any
-
-	function hideHoverStrap(){
-		showHoverStrap = false
-	}
-
-	onMount(() => {
-		hoverStrapTimeout = setTimeout(hideHoverStrap, 10000);
-	})
 </script>
 
 <header class:has-background={showBackground}>
-	{#if $page.url.pathname === '/'}
-		<Strap />
-	{/if}
 	<div class="navbar">
 		<a class="logo" href="/" aria-label="Site logo">
 			<Logo />
@@ -44,9 +28,11 @@
 			<div class="links-wrapper">
 				<ul class="links">
 					<li>
-						<button on:click={closeMenu}>
-							<Socials />
-						</button>
+						<Tooltip text='Watch our GitHub repos to stay up to date'>
+							<button on:click={closeMenu}>
+								<Socials />
+							</button>
+						</Tooltip>
 					</li>
 					<li>
 						<button on:click={closeMenu}>


### PR DESCRIPTION
This pull request introduces a tooltip to the GitHub icon in the header, encouraging users to follow us on GitHub. The tooltip replaces the strap at the top of the page.

Changes made:
- Created a Tooltip component which takes in a `text` prop which the tooltip displays with styling also from the Tooltip component.
- Added a tooltip to the GitHub icon in the header.
- Removed the strap at the top of the page.

This enhancement aims to improve user engagement and promote our presence on GitHub. Feel free to review the changes, and any feedback is welcome!
