### PR TITLE
fix some ESLint warnings

### DIFF
--- a/src/lib/components/atoms/Button.story.svelte
+++ b/src/lib/components/atoms/Button.story.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import '$lib/scss/global.scss';
-	import type { ComponentProps } from 'svelte';
 	import type { Hst as HstType } from '@histoire/plugin-svelte';
 	import Button from './Button.svelte';
 	import type { NoUndefinedField } from '$lib/utils/types';
@@ -8,13 +7,22 @@
 
 	export let Hst: HstType;
 
-	let props: NoUndefinedField<ComponentProps<Button>> = {
+	let props: NoUndefinedField<{
+		color?: "primary" | "secondary";
+		style?: "solid" | "understated" | "clear";
+		size?: "small" | "medium" | "large";
+		href?: string;
+		additionalClass?: string;
+		target?: "_self" | "_blank";
+		rel?: string;
+	}> = {
 		color: 'primary',
 		style: 'solid',
 		size: 'medium',
 		href: '',
 		target: '_blank',
-		rel: 'noopener noreferrer'
+		rel: 'noopener noreferrer',
+		additionalClass: '',
 	};
 
 	let text = 'This is a Button';

--- a/src/lib/components/atoms/ShareButton.svelte
+++ b/src/lib/components/atoms/ShareButton.svelte
@@ -6,7 +6,6 @@
     export let title: string;
 
     const encodedSubject = encodeURIComponent("I wanted you to see this blog post");
-    const encodedTitle = encodeURIComponent(title);
     const encodedBody = encodeURIComponent(`${title} is a really interesting blog post from Torrust. Check it out here: ${siteBaseUrl}/${slug}`)
     const encodedSlug = encodeURIComponent(slug);
 

--- a/src/lib/components/atoms/SingleSparkle.svelte
+++ b/src/lib/components/atoms/SingleSparkle.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+	interface Style {
+		top: string;
+		left: string;
+	}
+
 	export let color: string;
 	export let size: string;
-	export let style: any;
+	export let style: Style;
 </script>
 
 <div class="wrapper" style="top: {style.top}; left: {style.left};">

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -1,11 +1,16 @@
 export type NoUndefinedField<T> = { [P in keyof T]-?: NoUndefinedField<NonNullable<T[P]>> };
 
+type SparkleStyle = {
+	top: string;
+	left: string;
+};
+
 export type SparkleType = {
 	id: string;
 	createdAt: number;
 	color: string;
 	size: number;
-	style: any;
+	style: SparkleStyle;
 };
 
 export type TagType = {
@@ -13,7 +18,7 @@ export type TagType = {
 	color?: 'primary' | 'secondary';
 };
 
-export type SocialLink = {};
+export type SocialLink = object;
 
 export type Feature = {
 	name: string;


### PR DESCRIPTION
* Removed assigned but never used value `encodeTitle` from `ShareButton.svelte`
* Created an interface `Style` to replace unexpected `any` in `SingleSparkle.svelte`
* Refine `Button.story.svelte' props type definition, explicitly specifying optional properties like `additionalClass` and enhancing clarity on existing property types.
* Refactor types using `NoUndefinedField` utility to ensure non-nullable and non-undefined properties, and update `SparkleType` to specify a nested `SparkleStyle` object for the 'style' property.