### PR TITLE
Fix cover image stretching across page, add blog posts to each contributor's page

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -29,6 +29,8 @@
 		/>
 		<link rel="shortcut icon" href="%sveltekit.assets%/favicons/favicon.ico" />
 		<link rel="icon" href="%sveltekit.assets%/favicons/favicon.png" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
+
 
 		<!-- Tell browser this site is responsive -->
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/lib/components/atoms/ShareButton.svelte
+++ b/src/lib/components/atoms/ShareButton.svelte
@@ -48,6 +48,7 @@
 <style lang="scss">
 	.link-container {
 		display: flex;
+		justify-content: center;
 		gap: 1rem;
 	}
 </style>

--- a/src/lib/components/molecules/ContributorCard.svelte
+++ b/src/lib/components/molecules/ContributorCard.svelte
@@ -2,7 +2,6 @@
 	import Email from '$lib/icons/socials/email.svelte';
 	import Github from '$lib/icons/socials/github.svelte';
 	import Linkedin from '$lib/icons/socials/linkedin.svelte';
-	import Button from '$lib/components/atoms/Button.svelte';
 
 	export let name: string;
 	export let position: string | undefined = undefined;
@@ -43,9 +42,6 @@
 			<p>{@html para.para}</p>
 		{/each}
 	</div>
-	<Button>
-		<a href="/contributors" class="contributor-link">Return to Contributors</a>
-	</Button>
 </div>
 
 <style lang="scss">
@@ -122,10 +118,5 @@
 		font-size: 1rem;
 		text-align: justify;
 		margin: 1rem 0;
-	}
-
-	.contributor-link {
-		font-weight: bolder;
-		color: #fff;
 	}
 </style>

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -53,33 +53,37 @@
 			<div class="header">
 				{#if post}
 					<h1>{post.title}</h1>
-					<div class="note">Published on {formatDate(post.date)}</div>
-					{#if post.updated}
-						<div class="note">Updated on {formatDate(post.updated)}</div>
-					{/if}
-					{#if post.readingTime}
-						<div class="note">{post.readingTime}</div>
-					{/if}
-					{#if post.contributor}
-						<div>
-							<span>By: </span><a href="/{post.contributorSlug}">{post.contributor}</a>
+					<div class="article-content-flex">
+						<div class="article-content-text">
+							<div class="note">Published on {formatDate(post.date)}</div>
+							{#if post.updated}
+								<div class="note">Updated on {formatDate(post.updated)}</div>
+							{/if}
+							{#if post.readingTime}
+								<div class="note">{post.readingTime}</div>
+							{/if}
+							{#if post.contributor}
+								<div>
+									<span>By: </span><a href="/{post.contributorSlug}">{post.contributor}</a>
+								</div>
+							{/if}
+							<ShareButton slug={post.slug} title={post.title} />
+							{#if post.tags?.length}
+								<div class="tags">
+									{#each post.tags as tag}
+										<Tag>{tag}</Tag>
+									{/each}
+								</div>
+							{/if}
 						</div>
-					{/if}
-					<ShareButton slug={post.slug} title={post.title} />
-					{#if post.tags?.length}
-						<div class="tags">
-							{#each post.tags as tag}
-								<Tag>{tag}</Tag>
-							{/each}
-						</div>
-					{/if}
+						{#if post && post.coverImage}
+							<div class="cover-image">
+								<Image src={post.coverImage} alt={post.title} />
+							</div>
+						{/if}
+					</div>
 				{/if}
 			</div>
-			{#if post && post.coverImage}
-				<div class="cover-image">
-					<Image src={post.coverImage} alt={post.title} />
-				</div>
-			{/if}
 			<div class="content">
 				<slot />
 			</div>
@@ -110,6 +114,16 @@
 		padding-bottom: 80px;
 		padding-right: 15px;
 		padding-left: 15px;
+
+		.article-content-text {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+
+		.cover-image {
+			padding-top: 1.5rem;
+		}
 
 		@include for-iphone-se {
 			padding-left: 0;

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -53,37 +53,33 @@
 			<div class="header">
 				{#if post}
 					<h1>{post.title}</h1>
-					<div class="article-content-flex">
-						<div class="article-content-text">
-							<div class="note">Published on {formatDate(post.date)}</div>
-							{#if post.updated}
-								<div class="note">Updated on {formatDate(post.updated)}</div>
-							{/if}
-							{#if post.readingTime}
-								<div class="note">{post.readingTime}</div>
-							{/if}
-							{#if post.contributor}
-								<div>
-									<span>By: </span><a href="/{post.contributorSlug}">{post.contributor}</a>
-								</div>
-							{/if}
-							<ShareButton slug={post.slug} title={post.title} />
-							{#if post.tags?.length}
-								<div class="tags">
-									{#each post.tags as tag}
-										<Tag>{tag}</Tag>
-									{/each}
-								</div>
-							{/if}
+					<div class="note">Published on {formatDate(post.date)}</div>
+					{#if post.updated}
+						<div class="note">Updated on {formatDate(post.updated)}</div>
+					{/if}
+					{#if post.readingTime}
+						<div class="note">{post.readingTime}</div>
+					{/if}
+					{#if post.contributor}
+						<div>
+							<span>By: </span><a href="/{post.contributorSlug}">{post.contributor}</a>
 						</div>
-						{#if post && post.coverImage}
-							<div class="cover-image">
-								<Image src={post.coverImage} alt={post.title} />
-							</div>
-						{/if}
-					</div>
+					{/if}
+					<ShareButton slug={post.slug} title={post.title} />
+					{#if post.tags?.length}
+						<div class="tags">
+							{#each post.tags as tag}
+								<Tag>{tag}</Tag>
+							{/each}
+						</div>
+					{/if}
 				{/if}
 			</div>
+			{#if post && post.coverImage}
+				<div class="cover-image">
+					<Image src={post.coverImage} alt={post.title} />
+				</div>
+			{/if}
 			<div class="content">
 				<slot />
 			</div>
@@ -114,12 +110,6 @@
 		padding-bottom: 80px;
 		padding-right: 15px;
 		padding-left: 15px;
-
-		.article-content-text {
-			display: flex;
-			flex-direction: column;
-			gap: 0.5rem;
-		}
 
 		.cover-image {
 			padding-top: 1.5rem;

--- a/src/routes/(blog-article)/benchmarking-the-torrust-bittorrent-tracker/+page.md
+++ b/src/routes/(blog-article)/benchmarking-the-torrust-bittorrent-tracker/+page.md
@@ -3,6 +3,7 @@ title: Benchmarking the Torrust BitTorrent Tracker
 slug: benchmarking-the-torrust-bittorrent-tracker
 coverImage: /images/posts/benchmarking-the-torrust-bittorrent-tracker/benchmarking-the-torrust-bittorrent-tracker-banner.webp
 date: 2024-03-19T00:00:00.000Z
+updated:
 excerpt: In the ever-evolving landscape of BitTorrent technology, performance and scalability are paramount. Torrust stands at the forefront, offering a suite of open-source software products designed to enhance peer-to-peer file sharing. At the heart of this suite is the Torrust BitTorrent Tracker, a Rust-based engine crafted for efficiency and speed. This post will introduce you to the benchmarking tools we are using at the moment for the tracker.
 contributor: Jose Celano
 contributorSlug: jose-celano

--- a/src/routes/(blog-article)/containerizing-rust-applications-best-practices/+page.md
+++ b/src/routes/(blog-article)/containerizing-rust-applications-best-practices/+page.md
@@ -3,6 +3,7 @@ title: Containerizing Rust Applications
 slug: containerizing-rust-applications-best-practices
 coverImage: /images/posts/rust-crab-carrying-a-shipping-container.jpeg
 date: 2023-11-09T12:08:04.295Z
+updated:
 excerpt: Torrust services (Tracker and Index) support docker, we want to ensure that contributors understand our containerfile and we also want to share good practices for containerizing Rust applications.
 contributor: Jose Celano
 contributorSlug: jose-celano

--- a/src/routes/(blog-article)/deploying-torrust-to-production/+page.md
+++ b/src/routes/(blog-article)/deploying-torrust-to-production/+page.md
@@ -3,6 +3,7 @@ title: Deploying Torrust To Production
 slug: deploying-torrust-to-production
 coverImage: /images/posts/deploying-torrust-to-production/deploy-torrust-to-a-digital-ocean-droplet.png
 date: 2023-12-20T00:00:00.000Z
+updated:
 excerpt: Dive into our step-by-step tutorial on deploying a BitTorrent Index and Tracker, written in Rust, on a Digital Ocean droplet. From initial server setup to advanced configurations, this guide is designed for both non-developers and tech-savvy users, ensuring a seamless, production-ready deployment.
 contributor: Jose Celano
 contributorSlug: jose-celano

--- a/src/routes/(blog-article)/how-to-contribute-to-this-site/+page.md
+++ b/src/routes/(blog-article)/how-to-contribute-to-this-site/+page.md
@@ -3,6 +3,7 @@ title: How To Contribute To This Site
 slug: how-to-contribute-to-this-site
 coverImage: /images/posts/sample-post.jpg
 date: 2023-04-22T21:55:15.361Z
+updated:
 excerpt: How to manage existing blog posts and create new ones on this site.
 tags:
   - Documentation

--- a/src/routes/(blog-article)/how-to-run-a-local-demo/+page.md
+++ b/src/routes/(blog-article)/how-to-run-a-local-demo/+page.md
@@ -3,6 +3,7 @@ title: How To Run A Local Demo
 slug: how-to-run-a-local-demo
 coverImage: /images/posts/mandelbrot-set-periods-torrent-screenshot.png
 date: 2023-07-11T15:28:28.769Z
+updated: 2023-07-11T15:28:29.783Z
 excerpt: You can easily run the Torrust Index demo on your computer easily with Git and Docker.
 contributor: Jose Celano
 contributorSlug: jose-celano
@@ -11,7 +12,6 @@ tags:
   - Tutorial
   - Guide
 hidden: false
-updated: 2023-07-11T15:28:29.783Z
 ---
 
 <script>

--- a/src/routes/(blog-article)/how-to-setup-the-development-environment/+page.md
+++ b/src/routes/(blog-article)/how-to-setup-the-development-environment/+page.md
@@ -3,6 +3,7 @@ title: How To Setup The Dev Env
 slug: how-to-setup-the-development-environment
 coverImage: /images/posts/development-environment.png
 date: 2023-07-11T12:29:04.295Z
+updated:
 excerpt: If you want to contribute to the Torrust Index, this article explains how to setup a development environment with the latest versions for all services.
 contributor: Jose Celano
 contributorSlug: jose-celano

--- a/src/routes/(blog-article)/introducing-the-new-sample-torrent-migration-tool/+page.md
+++ b/src/routes/(blog-article)/introducing-the-new-sample-torrent-migration-tool/+page.md
@@ -3,6 +3,7 @@ title: Introducing the New Sample Torrent Migration Tool
 slug: introducing-the-new-sample-torrent-migration-tool
 coverImage: /images/posts/pexels-david-dibert-7177008.jpg
 date: 2023-09-04T13:24:27.241Z
+updated:
 excerpt: Looking to migrate to the Torrust Index? Dive into our Torrents Importer Sample to seamlessly transfer your torrents to Torrust.
 contributor: Jose Celano
 contributorSlug: jose-celano

--- a/src/routes/(blog-article)/live-demo-beta-v3/+page.md
+++ b/src/routes/(blog-article)/live-demo-beta-v3/+page.md
@@ -3,6 +3,7 @@ title: Announcing the Beta v3.0.0 Live Demo
 slug: live-demo-beta-v3
 coverImage: /images/posts/rust-crab-happy.jpg
 date: 2023-12-15T12:08:04.295Z
+updated:
 excerpt: We will release a new major version v3.0.0. We want the community to test it before the final release while it's still in Beta. You can contribute to make Torrust better.
 contributor: Jose Celano
 contributorSlug: jose-celano

--- a/src/routes/(blog-article)/profiling-the-torrust-bittorrent-udp-tracker/+page.md
+++ b/src/routes/(blog-article)/profiling-the-torrust-bittorrent-udp-tracker/+page.md
@@ -3,6 +3,7 @@ title: Profiling the Torrust BitTorrent UDP Tracker
 slug: profiling-the-torrust-bittorrent-udp-tracker
 coverImage: /images/posts/profiling-the-torrust-bittorrent-udp-tracker/profiling-the-torrust-bittorrent-udp-tracker.webp
 date: 2024-03-25T00:00:00.000Z
+updated:
 excerpt: Dive into the advanced profiling techniques driving the Torrust BitTorrent Tracker's performance. This post uncovers the tools and methods we leverage to ensure the tracker's efficiency, scalability, and our journey towards optimizing peer-to-peer file sharing.
 contributor: Jose Celano
 contributorSlug: jose-celano

--- a/src/routes/(blog-article)/the-enigmatic-torrent-source-field/+page.md
+++ b/src/routes/(blog-article)/the-enigmatic-torrent-source-field/+page.md
@@ -3,6 +3,7 @@ title: The Enigmatic Torrent "Source" Field
 slug: the-enigmatic-torrent-source-field
 coverImage: /images/posts/deprecated-and-outdated-bittorrent-documentation.png
 date: 2023-08-08T13:56:28.769Z
+updated: 2023-08-08T13:56:28.769Z
 excerpt: Delving into BitTorrent’s Mysteries. What is the "source" field in the torrent info used for?
 contributor: Jose Celano
 contributorSlug: jose-celano
@@ -10,7 +11,6 @@ tags:
   - BitTorrent
   - Protocol
 hidden: false
-updated: 2023-08-08T13:56:28.769Z
 ---
 
 <script>

--- a/src/routes/(blog-article)/what-is-a-bittorrent-tracker/+page.md
+++ b/src/routes/(blog-article)/what-is-a-bittorrent-tracker/+page.md
@@ -3,6 +3,7 @@ title: What is a BitTorrent tracker and types of trackers
 slug: what-is-a-bittorrent-tracker
 coverImage: /images/posts/tracker.jpg
 date: 2023-10-05T13:42:25.671Z
+updated:
 excerpt: Basic explanation of what a BitTorrent tracker is and the two types of trackers, public and private.
 tags:
   - Torrent

--- a/src/routes/(contributor)/+layout.server.ts
+++ b/src/routes/(contributor)/+layout.server.ts
@@ -1,0 +1,8 @@
+import { filteredPosts } from '$lib/data/blog-posts';
+
+export async function load() {
+	return {
+		posts: filteredPosts
+	};
+}
+

--- a/src/routes/(contributor)/+layout.svelte
+++ b/src/routes/(contributor)/+layout.svelte
@@ -1,10 +1,126 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import Header from '$lib/components/organisms/Header.svelte';
 	import Footer from '$lib/components/organisms/Footer.svelte';
+
+	import Button from '$lib/components/atoms/Button.svelte';
+	import BlogPostCard from '$lib/components/molecules/BlogPostCard.svelte';
+	import ContentSection from '$lib/components/organisms/ContentSection.svelte';
+	import type { BlogPost } from '$lib/utils/types';
+
+	export let data: {
+		posts: BlogPost[];
+	};
+
+	let { posts } = data;
+
+	let currentUrl: string | undefined = '';
+	let splitUrl: string | undefined = '';
+	let numberOfPosts: number | undefined;
+
+	onMount(() => {
+		currentUrl = window.location.href;
+		splitUrl = currentUrl.split('/').pop();
+
+		numberOfPosts = posts.filter((post) => post.contributorSlug === splitUrl).length;
+	});
 </script>
 
 <Header />
 
 <slot />
 
+<div class="container">
+	{#if posts && typeof numberOfPosts !== 'undefined' && numberOfPosts > 0}
+		<ContentSection title="All Blog Posts">
+			<div class="grid">
+				{#each posts as post}
+					{#if post.contributorSlug === splitUrl}
+						<BlogPostCard
+							title={post.title}
+							coverImage={post.coverImage}
+							excerpt={post.excerpt}
+							readingTime={post.readingTime}
+							slug={post.slug}
+							tags={post.tags}
+							date={post.date}
+						/>
+					{/if}
+				{/each}
+			</div>
+		</ContentSection>
+	{:else}
+		<ContentSection title="There's Nothing Here Yet." description="But check back again soon!">
+			<Button href="/contributors">Return to Contributors</Button>
+			<div class="empty-space" />
+		</ContentSection>
+	{/if}
+	<div class="contributor-link">
+		{#if posts && typeof numberOfPosts !== 'undefined' && numberOfPosts > 0}
+			<Button>
+				<a href="/contributors" class="contributor-link">Return to Contributors</a>
+			</Button>
+		{/if}
+	</div>
+</div>
+
 <Footer />
+
+<style lang="scss">
+	@import '$lib/scss/_mixins.scss';
+
+	.grid {
+		width: 100%;
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+		grid-gap: 20px;
+
+		@include for-tablet-portrait-down {
+			grid-template-columns: 1fr;
+		}
+
+		@include for-tablet-landscape-up {
+			// Select every 6 elements, starting from position 1
+			// And make it take up 6 columns
+			> :global(:nth-child(6n + 1)) {
+				grid-column: span 6;
+			}
+			// Select every 6 elements, starting from position 2
+			// And make it take up 3 columns
+			> :global(:nth-child(6n + 2)) {
+				grid-column: span 3;
+			}
+			// Select every 6 elements, starting from position 3
+			// And make it take up 3 columns
+			> :global(:nth-child(6n + 3)) {
+				grid-column: span 3;
+			}
+			// Select every 6 elements, starting from position 4, 5 and 6
+			// And make it take up 2 columns
+			> :global(:nth-child(6n + 4)),
+			:global(:nth-child(6n + 5)),
+			:global(:nth-child(6n + 6)) {
+				grid-column: span 2;
+			}
+		}
+	}
+
+	.empty-space {
+		height: calc(100vh - 700px);
+	}
+
+	:global(.waves-container) {
+		z-index: -1;
+	}
+
+	.contributor-link {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.contributor-link a {
+		font-weight: bolder;
+		color: #fff;
+	}
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,18 +67,18 @@
     "@lezer/highlight" "^1.0.0"
 
 "@codemirror/view@^6.0.0", "@codemirror/view@^6.16.0", "@codemirror/view@^6.23.0":
-  version "6.25.1"
-  resolved "https://registry.npmjs.org/@codemirror/view/-/view-6.25.1.tgz"
-  integrity sha512-2LXLxsQnHDdfGzDvjzAwZh2ZviNJm7im6tGpa0IONIDnFd8RZ80D2SNi8PDi6YjKcMoMRK20v6OmKIdsrwsyoQ==
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/@codemirror/view/-/view-6.26.0.tgz"
+  integrity sha512-nSSmzONpqsNzshPOxiKhK203R6BvABepugAe34QfQDbNDslyjkqBuKgrK5ZBvqNXpfxz5iLrlGTmEfhbQyH46A==
   dependencies:
     "@codemirror/state" "^6.4.0"
     style-mod "^4.1.0"
     w3c-keyname "^2.2.4"
 
-"@esbuild/linux-x64@0.18.20":
+"@esbuild/darwin-arm64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz"
-  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz"
+  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -413,9 +413,9 @@
   integrity sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==
 
 "@types/node@*", "@types/node@>= 14":
-  version "20.11.26"
-  resolved "https://registry.npmjs.org/@types/node/-/node-20.11.26.tgz"
-  integrity sha512-YwOMmyhNnAWijOBQweOJnQPl068Oqd4K3OFbTc6AHJwzweUwwWG3GIFY74OKks2PJUDkQPeddOQES9mLn1CTEQ==
+  version "20.11.30"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz"
+  integrity sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -645,14 +645,14 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 bare-events@^2.0.0, bare-events@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.2.1.tgz"
-  integrity sha512-9GYPpsPFvrWBkelIhOhTWtkeZxVxZOdb3VnFTCzlOo3OjvmTvzLoZFUT8kNFACx0vJej6QPney1Cf9BvzCNE/A==
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz"
+  integrity sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==
 
 bare-fs@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.1.tgz"
-  integrity sha512-+CjmZANQDFZWy4PGbVdmALIwmt33aJg8qTkVjClU6X4WmZkTPBDxRHiBn7fpqEWEfF3AC2io++erpViAIQbSjg==
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.2.tgz"
+  integrity sha512-X9IqgvyB0/VA5OZJyb5ZstoN62AzD7YxVGog13kkfYWYqJYcK0kcqLZ6TrmH5qr4/8//ejVcX4x/a0UvaogXmA==
   dependencies:
     bare-events "^2.0.0"
     bare-os "^2.0.0"
@@ -660,9 +660,9 @@ bare-fs@^2.1.1:
     streamx "^2.13.0"
 
 bare-os@^2.0.0, bare-os@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/bare-os/-/bare-os-2.2.0.tgz"
-  integrity sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/bare-os/-/bare-os-2.2.1.tgz"
+  integrity sha512-OwPyHgBBMkhC29Hl3O4/YfxW9n7mdTr2+SsO29XBWKKJsbgj3mnorDB80r5TiCQgQstgE5ga1qNYrpes6NvX2w==
 
 bare-path@^2.0.0, bare-path@^2.1.0:
   version "2.1.0"
@@ -677,9 +677,9 @@ base64-js@^1.3.1:
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
+  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
 birpc@^0.1.1:
   version "0.1.1"
@@ -984,9 +984,9 @@ detect-indent@^6.1.0:
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
 detect-libc@^2.0.0, detect-libc@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz"
-  integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz"
+  integrity sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==
 
 devalue@^4.3.1:
   version "4.3.2"
@@ -1409,6 +1409,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 gh-pages@^5.0.0:
   version "5.0.0"
@@ -2328,13 +2333,13 @@ pkg-types@^1.0.3:
     pathe "^1.1.0"
 
 "postcss@^7 || ^8", postcss@^8.4.27:
-  version "8.4.35"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz"
-  integrity sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==
+  version "8.4.38"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz"
+  integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
-    source-map-js "^1.0.2"
+    source-map-js "^1.2.0"
 
 prebuild-install@^7.1.1:
   version "7.1.2"
@@ -2553,9 +2558,9 @@ sander@^0.5.0:
     rimraf "^2.5.2"
 
 sass@*, sass@^1.26.8, sass@^1.67.2:
-  version "1.71.1"
-  resolved "https://registry.npmjs.org/sass/-/sass-1.71.1.tgz"
-  integrity sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==
+  version "1.72.0"
+  resolved "https://registry.npmjs.org/sass/-/sass-1.72.0.tgz"
+  integrity sha512-Gpczt3WA56Ly0Mn8Sl21Vj94s1axi9hDIzDFn9Ph9x3C3p4nNyvsqJoQyVXKou6cBlfFWEgRW4rT8Tb4i3XnVA==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -2696,10 +2701,10 @@ sorcery@^0.11.0:
     minimist "^1.2.0"
     sander "^0.5.0"
 
-source-map-js@^1.0.2, "source-map-js@>=0.6.2 <2.0.0":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz"
-  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+source-map-js@^1.2.0, "source-map-js@>=0.6.2 <2.0.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz"
+  integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
 source-map-support@^0.5.21:
   version "0.5.21"
@@ -2800,9 +2805,9 @@ supports-color@^7.1.0:
     has-flag "^4.0.0"
 
 svelte-check@^3.4.5:
-  version "3.6.7"
-  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.7.tgz"
-  integrity sha512-tKEjemK9FYCySAseCaIt+ps5o0XRvLC7ECjyJXXtO7vOQhR9E6JavgoUbGP1PCulD2OTcB/fi9RjV3nyF1AROw==
+  version "3.6.8"
+  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.8.tgz"
+  integrity sha512-rhXU7YCDtL+lq2gCqfJDXKTxJfSsCgcd08d7VWBFxTw6IWIbMWSaASbAOD3N0VV9TYSSLUqEBiratLd8WxAJJA==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.17"
     chokidar "^3.4.1"
@@ -2973,9 +2978,9 @@ type-fest@^0.20.2:
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 typescript@^5.0.3, typescript@^5.1.3, "typescript@>=3.9.5 || ^4.0.0 || ^5.0.0", typescript@>=4.2.0:
-  version "5.4.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz"
-  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
+  version "5.4.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz"
+  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -2983,9 +2988,9 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 ufo@^1.3.2:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/ufo/-/ufo-1.4.0.tgz"
-  integrity sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==
+  version "1.5.3"
+  resolved "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz"
+  integrity sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
## Description:
This pull request enhances each contributor's page by adding a section at the bottom which displays the blog posts that particular contributor has published. In case a contributor hasn't published any posts, a message is shown indicating that none have been published yet, but to check back soon. On each contributor page, a button displays, either below the posts or the below the aforementioned message, a link back to the page which displays all of the contributors.

Additionally, the cover image layout issue in each blog post, as mentioned in [this issue](https://github.com/torrust/torrust-website/issues/158), has been addressed. The fix prevents the image from stretching across the page and cutting off the top and bottom portions of the image, ensuring a visually pleasing display. Flexbox has been put in place to display the page on large screens similar to the example below should there be interest in it:

<img width="1437" alt="Screenshot 2024-03-25 at 18 01 13" src="https://github.com/torrust/torrust-website/assets/95353365/8e066e1f-be86-47c3-aa1f-498af69129bf">

Furthermore, the update timestamp, as mentioned in [this issue](https://github.com/torrust/torrust-website/issues/151), has been incorporated into the front matter of each blog post. This feature allows users to see when a post has been last updated, providing valuable information about the post's freshness. If the blog post hasn't been updated then it will not appear on the page until a date for when the update was made has been added.

## Changes:

* Added a section displaying contributor's published posts with a message for no published posts.
* Fixed blog post cover images to prevent stretching and cropping.
* Included update timestamps for each blog post.