### PR TITLE
add storybooks to components missing them

### DIFF
--- a/src/lib/components/atoms/Image.story.svelte
+++ b/src/lib/components/atoms/Image.story.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import '$lib/scss/global.scss';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+	import Image from './Image.svelte';
+
+	export let Hst: HstType;
+
+	let src = 'https://placedog.net/500';
+	let alt = 'A cute dog';
+	let fullBleed: boolean | undefined = undefined;
+
+	let formats: string[] = ['avif', 'webp', 'png'];
+	let widths: string[] | undefined = undefined;
+
+	function buildSrcset() {
+		let srcset = '';
+		const fileName = src.split('.')[0];
+		const fileExtension = src.split('.').pop() || '';
+
+		if (widths) {
+			for (let i = 0; i < widths.length; i++) {
+				srcset += `${fileName}-${widths[i]}.${fileExtension} ${widths[i]}w`;
+
+				if (i < widths.length - 1) {
+					srcset += ', ';
+				}
+			}
+		} else {
+			for (let i = 0; i < formats.length; i++) {
+				srcset += `${fileName}.${formats[i]}`;
+
+				if (i < formats.length - 1) {
+					srcset += ', ';
+				}
+			}
+		}
+
+		return srcset;
+	}
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/Image">
+	<div style="padding: 10px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<Image {src} {alt} {fullBleed} />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/RssLink.story.svelte
+++ b/src/lib/components/atoms/RssLink.story.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import RssLink from './RssLink.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/RssLink">
+	<div style="padding: 10px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<RssLink />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/ShareButton.story.svelte
+++ b/src/lib/components/atoms/ShareButton.story.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import ShareButton from './ShareButton.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/ShareButton">
+	<div style="padding: 10px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<ShareButton slug="sample-slug" title="Sample Title" />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/SingleSparkle.story.svelte
+++ b/src/lib/components/atoms/SingleSparkle.story.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import SingleSparkle from './SingleSparkle.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/SingleSparkle">
+	<div style="padding: 10px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<SingleSparkle color="yellow" size="20px" style={{ top: '50px', left: '50px' }} />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/Strap.story.svelte
+++ b/src/lib/components/atoms/Strap.story.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import Strap from './Strap.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/Strap">
+	<div style="padding: 10px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<Strap />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/molecules/ContributorCard.story.svelte
+++ b/src/lib/components/molecules/ContributorCard.story.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import ContributorCard from './ContributorCard.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+
+	const sampleContributor = {
+		name: 'John Doe',
+		position: 'Software Engineer',
+		img: '/images/contributors/john_doe.jpg',
+		contributeDate: '2023-01-01',
+		paras: [
+			{
+				para: 'John Doe is a talented software engineer with a passion for building scalable applications.'
+			},
+			{
+				para: 'He joined our team in January 2023 and has been making valuable contributions ever since.'
+			}
+		],
+		links: [
+			{
+				email: 'mailto:john.doe@example.com',
+				github: 'https://github.com/johndoe',
+				linkedIn: 'https://www.linkedin.com/in/johndoe'
+			}
+		]
+	};
+</script>
+
+<svelte:component this={Hst.Story} title="Molecules/ContributorCard">
+	<div style="padding: 10px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<ContributorCard {...sampleContributor} />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/molecules/PostBody.story.svelte
+++ b/src/lib/components/molecules/PostBody.story.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import PostBody from './PostBody.svelte';
+
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Molecules/PostBody">
+	<PostBody>
+		<p>This is a sample post body.</p>
+		<p>It can contain multiple paragraphs of text.</p>
+		<p>You can insert any content inside the slot.</p>
+	</PostBody>
+</svelte:component>

--- a/src/lib/components/molecules/PostContainer.story.svelte
+++ b/src/lib/components/molecules/PostContainer.story.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import PostContainer from './PostContainer.svelte';
+
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Molecules/PostContainer">
+	<PostContainer />
+</svelte:component>

--- a/src/lib/components/molecules/PostTable.story.svelte
+++ b/src/lib/components/molecules/PostTable.story.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import PostTable from './PostTable.svelte';
+
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Molecules/PostTable">
+	<PostTable>
+		<p>This is a PostTable component!</p>
+	</PostTable>
+</svelte:component>

--- a/src/lib/components/molecules/ThemeToggle.story.svelte
+++ b/src/lib/components/molecules/ThemeToggle.story.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import ThemeToggle from './ThemeToggle.svelte';
+
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Molecules/ThemeToggle">
+	<ThemeToggle />
+</svelte:component>

--- a/src/lib/components/organisms/AboutTorrust.story.svelte
+++ b/src/lib/components/organisms/AboutTorrust.story.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import AboutTorrust from './AboutTorrust.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="About Torrust" layout={{ type: 'grid', width: 600 }}>
+	<div style="padding: 20px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<AboutTorrust />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/organisms/Features.story.svelte
+++ b/src/lib/components/organisms/Features.story.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import Features from './Features.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+	import type { Feature } from '$lib/utils/types';
+	import type { NoUndefinedField } from '$lib/utils/types';
+
+	const features: NoUndefinedField<Feature>[] = [
+		{
+			name: 'Feature 1',
+			description: 'Description of feature 1',
+			image: '/images/feature1.jpg',
+			tags: [{ label: 'Tag 1', color: 'primary' }]
+		},
+		{
+			name: 'Feature 2',
+			description: 'Description of feature 2',
+			image: '/images/feature2.jpg',
+			tags: [{ label: 'Tag 2', color: 'secondary' }]
+		}
+	];
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Features" layout={{ type: 'grid', width: 800 }}>
+	<div style="padding: 20px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<Features {features} />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/organisms/Footer.story.svelte
+++ b/src/lib/components/organisms/Footer.story.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import Footer from './Footer.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Footer" layout={{ type: 'grid', width: 800 }}>
+	<div style="padding: 20px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<Footer />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/organisms/HowToContribute.story.svelte
+++ b/src/lib/components/organisms/HowToContribute.story.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import HowToContribute from './HowToContribute.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="How to Contribute" layout={{ type: 'grid', width: 800 }}>
+	<div style="padding: 20px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<HowToContribute />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/organisms/RecentPosts.story.svelte
+++ b/src/lib/components/organisms/RecentPosts.story.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import RecentPosts from './RecentPosts.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+	import type { BlogPost } from '$lib/utils/types';
+
+	const posts: BlogPost[] = [
+		{
+			tags: ['Technology', 'Programming'],
+			keywords: ['Svelte', 'JavaScript', 'Web Development'],
+			hidden: false,
+			slug: 'getting-started-with-svelte',
+			title: 'Getting Started with Svelte',
+			date: '2024-04-28',
+			updated: '2024-04-29',
+			excerpt: 'Learn the basics of Svelte and start building web applications with ease.',
+			html: '<p>Content of the blog post...</p>',
+			readingTime: '5 minutes',
+			relatedPosts: [],
+			coverImage: '/images/svelte-cover.jpg',
+			contributorSlug: 'john-doe',
+			contributor: 'John Doe'
+		}
+	];
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Recent Posts" layout={{ type: 'grid', width: 800 }}>
+	<div style="padding: 20px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<RecentPosts {posts} />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/organisms/RelatedPosts.story.svelte
+++ b/src/lib/components/organisms/RelatedPosts.story.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import RelatedPosts from './RelatedPosts.svelte';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+	import type { BlogPost } from '$lib/utils/types';
+
+	const posts: BlogPost[] = [
+		{
+			tags: ['Technology', 'Programming'],
+			keywords: ['Svelte', 'JavaScript', 'Web Development'],
+			hidden: false,
+			slug: 'getting-started-with-svelte',
+			title: 'Getting Started with Svelte',
+			date: '2024-04-28',
+			updated: '2024-04-29',
+			excerpt: 'Learn the basics of Svelte and start building web applications with ease.',
+			html: '<p>Content of the blog post...</p>',
+			readingTime: '5 minutes',
+			relatedPosts: [],
+			coverImage: '/images/svelte-cover.jpg',
+			contributorSlug: 'john-doe',
+			contributor: 'John Doe'
+		}
+	];
+
+	export let Hst: HstType;
+</script>
+
+<svelte:component this={Hst.Story} title="Related Posts" layout={{ type: 'grid', width: 800 }}>
+	<div style="padding: 20px;">
+		<svelte:component this={Hst.Variant} title="Default">
+			<RelatedPosts {posts} />
+		</svelte:component>
+	</div>
+</svelte:component>


### PR DESCRIPTION
As outlined in #169, some components were missing a storybook. I have added storybooks to the following components which were missing them:

* Image
* RssLink
* ShareButton
* SingleSparkle
* Strap
* ContributorCard
* PostBody
* PostContainer
* PostTable
* ThemeToggle
* AboutTorrust
* Features
* Footer
* HowToContribute
* RecentPosts
* RelatedPosts