### PR TITLE
Page for tags in blog post, share button, and updated packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@fontsource-variable/roboto-mono": "^5.0.9",
-				"@fontsource-variable/roboto-slab": "^5.0.12"
+				"@fontsource-variable/roboto-slab": "^5.0.12",
+				"shiki": "^1.5.2"
 			},
 			"devDependencies": {
 				"@histoire/plugin-svelte": "^0.16.1",
@@ -602,6 +603,13 @@
 				"shiki-es": "^0.2.0"
 			}
 		},
+		"node_modules/@histoire/app/node_modules/shiki-es": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/shiki-es/-/shiki-es-0.2.0.tgz",
+			"integrity": "sha512-RbRMD+IuJJseSZljDdne9ThrUYrwBwJR04FvN4VXpfsU3MNID5VJGHLAD5je/HGThCyEKNgH+nEkSFEWKD7C3Q==",
+			"deprecated": "Please migrate to https://github.com/antfu/shikiji",
+			"dev": true
+		},
 		"node_modules/@histoire/controls": {
 			"version": "0.16.5",
 			"resolved": "https://registry.npmjs.org/@histoire/controls/-/controls-0.16.5.tgz",
@@ -908,6 +916,11 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
 			"integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
 			"dev": true
+		},
+		"node_modules/@shikijs/core": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.5.2.tgz",
+			"integrity": "sha512-wSAOgaz48GmhILFElMCeQypSZmj6Ru6DttOOtl3KNkdJ17ApQuGNCfzpk4cClasVrnIu45++2DBwG4LNMQAfaA=="
 		},
 		"node_modules/@sveltejs/adapter-static": {
 			"version": "2.0.3",
@@ -2364,9 +2377,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "2.38.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.38.0.tgz",
-			"integrity": "sha512-IwwxhHzitx3dr0/xo0z4jjDlb2AAHBPKt+juMyKKGTLlKi1rZfA4qixMwnveU20/JTHyipM6keX4Vr7LZFYc9g==",
+			"version": "2.39.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.39.0.tgz",
+			"integrity": "sha512-FXktBLXsrxbA+6ZvJK2z/sQOrUKyzSg3fNWK5h0reSCjr2fjAsc9ai/s/JvSl4Hgvz3nYVtTIMwarZH5RcB7BA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
@@ -2374,13 +2387,13 @@
 				"debug": "^4.3.4",
 				"eslint-compat-utils": "^0.5.0",
 				"esutils": "^2.0.3",
-				"known-css-properties": "^0.30.0",
+				"known-css-properties": "^0.31.0",
 				"postcss": "^8.4.38",
 				"postcss-load-config": "^3.1.4",
 				"postcss-safe-parser": "^6.0.0",
 				"postcss-selector-parser": "^6.0.16",
 				"semver": "^7.6.0",
-				"svelte-eslint-parser": ">=0.35.0 <1.0.0"
+				"svelte-eslint-parser": ">=0.36.0 <1.0.0"
 			},
 			"engines": {
 				"node": "^14.17.0 || >=16.0.0"
@@ -3179,6 +3192,13 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/histoire/node_modules/shiki-es": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/shiki-es/-/shiki-es-0.2.0.tgz",
+			"integrity": "sha512-RbRMD+IuJJseSZljDdne9ThrUYrwBwJR04FvN4VXpfsU3MNID5VJGHLAD5je/HGThCyEKNgH+nEkSFEWKD7C3Q==",
+			"deprecated": "Please migrate to https://github.com/antfu/shikiji",
+			"dev": true
+		},
 		"node_modules/histoire/node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -3591,9 +3611,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.30.0.tgz",
-			"integrity": "sha512-VSWXYUnsPu9+WYKkfmJyLKtIvaRJi1kXUqVmBACORXZQxT5oZDsoZ2vQP+bQFDnWtpI/4eq3MLoRMjI2fnLzTQ==",
+			"version": "0.31.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.31.0.tgz",
+			"integrity": "sha512-sBPIUGTNF0czz0mwGGUoKKJC8Q7On1GPbCSFPfyEsfHb2DyBG0Y4QtV+EVWpINSaiGKZblDNuF5AezxSgOhesQ==",
 			"dev": true
 		},
 		"node_modules/launch-editor": {
@@ -4880,9 +4900,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.76.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.76.0.tgz",
-			"integrity": "sha512-nc3LeqvF2FNW5xGF1zxZifdW3ffIz5aBb7I7tSvOoNu7z1RQ6pFt9MBuiPtjgaI62YWrM/txjWlOCFiGtf2xpw==",
+			"version": "1.77.1",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.77.1.tgz",
+			"integrity": "sha512-OMEyfirt9XEfyvocduUIOlUSkWOXS/LAt6oblR/ISXCTukyavjex+zQNm51pPCOiFKY1QpWvEH1EeCkgyV3I6w==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
@@ -5006,12 +5026,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/shiki-es": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/shiki-es/-/shiki-es-0.2.0.tgz",
-			"integrity": "sha512-RbRMD+IuJJseSZljDdne9ThrUYrwBwJR04FvN4VXpfsU3MNID5VJGHLAD5je/HGThCyEKNgH+nEkSFEWKD7C3Q==",
-			"deprecated": "Please migrate to https://github.com/antfu/shikiji",
-			"dev": true
+		"node_modules/shiki": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.5.2.tgz",
+			"integrity": "sha512-fpPbuSaatinmdGijE7VYUD3hxLozR3ZZ+iAx8Iy2X6REmJGyF5hQl94SgmiUNTospq346nXUVZx0035dyGvIVw==",
+			"dependencies": {
+				"@shikijs/core": "1.5.2"
+			}
 		},
 		"node_modules/simple-concat": {
 			"version": "1.0.1",
@@ -5293,9 +5314,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "4.2.15",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.15.tgz",
-			"integrity": "sha512-j9KJSccHgLeRERPlhMKrCXpk2TqL2m5Z+k+OBTQhZOhIdCCd3WfqV+ylPWeipEwq17P/ekiSFWwrVQv93i3bsg==",
+			"version": "4.2.17",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.17.tgz",
+			"integrity": "sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
@@ -5318,9 +5339,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.7.0.tgz",
-			"integrity": "sha512-Va6sGL4Vy4znn0K+vaatk98zoBvG2aDee4y3r5X4S80z8DXfbACHvdLlyXa4C4c5tQzK9H0Uq2pbd20wH3ucjQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.7.1.tgz",
+			"integrity": "sha512-U4uJoLCzmz2o2U33c7mPDJNhRYX/DNFV11XTUDlFxaKLsO7P+40gvJHMPpoRfa24jqZfST4/G9fGNcUGMO8NAQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -5340,9 +5361,9 @@
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
-			"version": "0.35.0",
-			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.35.0.tgz",
-			"integrity": "sha512-CtbPseajW0gjwEvHiuzYJkPDjAcHz2FaHt540j6RVYrZgnE6xWkzUBodQ4I3nV+G5AS0Svt8K6aIA/CIU9xT2Q==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.36.0.tgz",
+			"integrity": "sha512-/6YmUSr0FAVxW8dXNdIMydBnddPMHzaHirAZ7RrT21XYdgGGZMh0LQG6CZsvAFS4r2Y4ItUuCQc8TQ3urB30mQ==",
 			"dev": true,
 			"dependencies": {
 				"eslint-scope": "^7.2.2",
@@ -5358,7 +5379,7 @@
 				"url": "https://github.com/sponsors/ota-meshi"
 			},
 			"peerDependencies": {
-				"svelte": "^3.37.0 || ^4.0.0 || ^5.0.0-next.112"
+				"svelte": "^3.37.0 || ^4.0.0 || ^5.0.0-next.115"
 			},
 			"peerDependenciesMeta": {
 				"svelte": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 	"type": "module",
 	"dependencies": {
 		"@fontsource-variable/roboto-mono": "^5.0.9",
-		"@fontsource-variable/roboto-slab": "^5.0.12"
+		"@fontsource-variable/roboto-slab": "^5.0.12",
+		"shiki": "^1.5.2"
 	},
 	"packageManager": "yarn@4.1.0"
 }

--- a/src/lib/components/atoms/Tag.story.svelte
+++ b/src/lib/components/atoms/Tag.story.svelte
@@ -8,10 +8,10 @@
 
 <svelte:component this={Hst.Story} title="Atoms/Tag" layout={{ type: 'grid', width: 200 }}>
 	<svelte:component this={Hst.Variant} title="Primary">
-		<Tag>This is a Tag</Tag>
+		<Tag tag="example-tag">This is a Tag</Tag>
 	</svelte:component>
 
 	<svelte:component this={Hst.Variant} title="Secondary">
-		<Tag color="secondary">This is a Tag</Tag>
+		<Tag color="secondary" tag="example-tag">This is a Tag</Tag>
 	</svelte:component>
 </svelte:component>

--- a/src/lib/components/atoms/Tag.svelte
+++ b/src/lib/components/atoms/Tag.svelte
@@ -5,11 +5,12 @@
 	export let color: 'primary' | 'secondary' = 'primary';
 
 	export let href: string | undefined = undefined;
+	export let tag: string;
 	const isExternalLink = !!href && HttpRegex.test(href);
 	export let target: '_self' | '_blank' = isExternalLink ? '_blank' : '_self';
 	export let rel = isExternalLink ? 'noopener noreferrer' : undefined;
 
-	$: tag = href ? 'a' : 'div';
+	$: tagElement = href ? 'a' : 'div';
 	$: linkProps = {
 		href,
 		target,
@@ -17,12 +18,16 @@
 	};
 </script>
 
-<svelte:element this={tag} class="tag {color}" {...linkProps}>
-	<slot />
+<svelte:element this={tagElement} class="tag {color}" {...linkProps}>
 	{#if isExternalLink}
 		<div class="icon">
+			{tag}
 			<ExternalLinkIcon />
 		</div>
+	{:else}
+		<a data-sveltekit-reload href="/tags/{tag}">
+			<slot />
+		</a>
 	{/if}
 </svelte:element>
 
@@ -50,8 +55,10 @@
 	}
 
 	.icon {
-		width: 16px;
-		height: 16px;
+		display: flex;
+		gap: 15px;
+		width: 100%;
+		height: 20px;
 	}
 
 	a.tag {

--- a/src/lib/components/molecules/BlogPostCard.svelte
+++ b/src/lib/components/molecules/BlogPostCard.svelte
@@ -47,7 +47,7 @@
 		{#if tags?.length}
 			<div class="tags">
 				{#each tags.slice(0, 2) as tag}
-					<Tag>{tag}</Tag>
+					<Tag {tag}><a href="/tags/{tag}">{tag}</a></Tag>
 				{/each}
 			</div>
 		{/if}

--- a/src/lib/components/molecules/FeatureCard.svelte
+++ b/src/lib/components/molecules/FeatureCard.svelte
@@ -26,7 +26,7 @@
 		{#if tags && tags.length > 0}
 			<div class="tags">
 				{#each tags as tag}
-					<Tag color={tag.color}>{tag.label}</Tag>
+					<Tag tag={tag.label} color={tag.color}>{tag.label}</Tag>
 				{/each}
 			</div>
 		{/if}

--- a/src/lib/components/molecules/ProjectCard.svelte
+++ b/src/lib/components/molecules/ProjectCard.svelte
@@ -63,7 +63,7 @@
 		{#if tags?.length}
 			<div class="tags">
 				{#each tags as tag}
-					<Tag>{tag}</Tag>
+					<Tag {tag}>{tag}</Tag>
 				{/each}
 			</div>
 		{/if}

--- a/src/lib/components/singletons/ContributionCard.svelte
+++ b/src/lib/components/singletons/ContributionCard.svelte
@@ -18,7 +18,7 @@
 		{#if links && links.length}
 			<div class="links">
 				{#each links as link}
-					<Tag color="secondary" href={link.href}>{link.label}</Tag>
+					<Tag tag={link.label} color="secondary" href={link.href}>{link.label}</Tag>
 				{/each}
 			</div>
 		{/if}

--- a/src/lib/components/singletons/ShareButton.svelte
+++ b/src/lib/components/singletons/ShareButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
 	import { siteBaseUrl } from '$lib/data/meta';
+	import ShareUrl from './ShareUrl.svelte';
 
 	export let slug: string;
 	export let title: string;
@@ -43,6 +44,7 @@
 			<Icon {icon} width="30" height="30" {color} />
 		</a>
 	{/each}
+	<ShareUrl />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/singletons/ShareUrl.svelte
+++ b/src/lib/components/singletons/ShareUrl.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { writable } from 'svelte/store';
+	import Icon from '@iconify/svelte';
+
+	let currentUrl: string = '';
+	let isCopied = writable(false);
+
+	onMount(() => {
+		currentUrl = window.location.href;
+	});
+
+	function copyUrlToClipboard() {
+		const textarea = document.createElement('textarea');
+		textarea.value = currentUrl;
+		document.body.appendChild(textarea);
+
+		textarea.select();
+		textarea.setSelectionRange(0, 99999);
+
+		document.execCommand('copy');
+
+		document.body.removeChild(textarea);
+
+		isCopied.set(true);
+
+		setTimeout(() => {
+			isCopied.set(false);
+		}, 3000);
+	}
+</script>
+
+<div>
+	<button class:copied={$isCopied} on:click={copyUrlToClipboard}>
+		{#if $isCopied}
+			<span>
+				<Icon icon="charm:tick" color="#6cdb2e" width="24" height="24" />
+			</span>
+		{:else}
+			<span>
+				<Icon icon="material-symbols:share-outline" width="24" height="24" style="color: #ffffff" />
+			</span>
+		{/if}
+		<span>{$isCopied ? 'Link copied' : 'Share'}</span>
+	</button>
+</div>
+
+<style lang="scss">
+	button {
+		display: flex;
+		gap: 0.2rem;
+		border-radius: 10px;
+		padding: 1.5px 15px;
+		border: none;
+		background-color: #650000;
+		color: #ffffff;
+		white-space: nowrap;
+	}
+
+	button:hover {
+		background-color: #f26f39;
+		cursor: pointer;
+		color: #ffffff;
+	}
+</style>

--- a/src/lib/components/singletons/ShareUrl.svelte
+++ b/src/lib/components/singletons/ShareUrl.svelte
@@ -1,32 +1,28 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { writable } from 'svelte/store';
+	import { page } from '$app/stores';
 	import Icon from '@iconify/svelte';
 
 	let currentUrl: string = '';
 	let isCopied = writable(false);
 
 	onMount(() => {
-		currentUrl = window.location.href;
+		currentUrl = $page.url.origin + $page.url.pathname;
 	});
 
 	function copyUrlToClipboard() {
-		const textarea = document.createElement('textarea');
-		textarea.value = currentUrl;
-		document.body.appendChild(textarea);
-
-		textarea.select();
-		textarea.setSelectionRange(0, 99999);
-
-		document.execCommand('copy');
-
-		document.body.removeChild(textarea);
-
-		isCopied.set(true);
-
-		setTimeout(() => {
-			isCopied.set(false);
-		}, 3000);
+		navigator.clipboard
+			.writeText(currentUrl)
+			.then(() => {
+				isCopied.set(true);
+				setTimeout(() => {
+					isCopied.set(false);
+				}, 3000);
+			})
+			.catch((error) => {
+				console.error('Error copying to clipboard:', error);
+			});
 	}
 </script>
 

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -69,7 +69,11 @@
 					{#if post.tags?.length}
 						<div class="tags">
 							{#each post.tags as tag}
-								<Tag>{tag}</Tag>
+								<Tag>
+									<a href="/tags/{tag}">
+										{tag}
+									</a>
+								</Tag>
 							{/each}
 						</div>
 					{/if}

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -69,10 +69,8 @@
 					{#if post.tags?.length}
 						<div class="tags">
 							{#each post.tags as tag}
-								<Tag>
-									<a href="/tags/{tag}">
-										{tag}
-									</a>
+								<Tag {tag}>
+									{tag}
 								</Tag>
 							{/each}
 						</div>

--- a/src/routes/tags/+layout.svelte
+++ b/src/routes/tags/+layout.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import Header from '$lib/components/organisms/Header.svelte';
+	import Footer from '$lib/components/organisms/Footer.svelte';
+</script>
+
+<Header />
+<slot />
+<Footer />

--- a/src/routes/tags/[tagId]/+page.server.ts
+++ b/src/routes/tags/[tagId]/+page.server.ts
@@ -1,0 +1,7 @@
+import { filteredPosts } from '$lib/data/blog-posts';
+
+export async function load() {
+	return {
+		posts: filteredPosts
+	};
+}

--- a/src/routes/tags/[tagId]/+page.svelte
+++ b/src/routes/tags/[tagId]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 	import type { BlogPost } from '$lib/utils/types';
 	import BlogPostCard from '$lib/components/molecules/BlogPostCard.svelte';
 	import ContentSection from '$lib/components/organisms/ContentSection.svelte';
@@ -8,13 +9,13 @@
 	let splitUrl: string = '';
 
 	export let data: {
-		posts?: BlogPost[]; // Marking as optional to allow for async initialization
+		posts?: BlogPost[];
 	};
 
-	let posts: BlogPost[] = data.posts || []; // Initialize posts with an empty array as a fallback
+	let posts: BlogPost[] = data.posts || [];
 
 	onMount(() => {
-		currentUrl = window.location.href;
+		currentUrl = $page.url.pathname;
 		splitUrl = decodeURIComponent(currentUrl.split('/').pop()! || '');
 		console.log(splitUrl);
 	});

--- a/src/routes/tags/[tagId]/+page.svelte
+++ b/src/routes/tags/[tagId]/+page.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { BlogPost } from '$lib/utils/types';
+	import BlogPostCard from '$lib/components/molecules/BlogPostCard.svelte';
+	import ContentSection from '$lib/components/organisms/ContentSection.svelte';
+
+	let currentUrl: string | undefined = '';
+	let splitUrl: string = '';
+
+	export let data: {
+		posts?: BlogPost[]; // Marking as optional to allow for async initialization
+	};
+
+	let posts: BlogPost[] = data.posts || []; // Initialize posts with an empty array as a fallback
+
+	onMount(() => {
+		currentUrl = window.location.href;
+		splitUrl = decodeURIComponent(currentUrl.split('/').pop()! || '');
+		console.log(splitUrl);
+	});
+</script>
+
+<div class="container">
+	<ContentSection title={splitUrl}>
+		{#if posts && posts.length > 0}
+			{#each posts as post}
+				{#if post.tags && post.tags.includes(splitUrl)}
+					<div class="grid">
+						<BlogPostCard
+							title={post.title}
+							coverImage={post.coverImage}
+							excerpt={post.excerpt}
+							readingTime={post.readingTime}
+							slug={post.slug}
+							tags={post.tags}
+							date={post.date}
+						/>
+					</div>
+				{/if}
+			{/each}
+		{:else}
+			<p>No posts available</p>
+		{/if}
+	</ContentSection>
+</div>
+
+<style lang="scss">
+	@import '$lib/scss/_mixins.scss';
+
+	.grid {
+		width: 100%;
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+		grid-gap: 20px;
+		margin-bottom: 2rem;
+
+		@include for-tablet-portrait-down {
+			grid-template-columns: 1fr;
+		}
+
+		@include for-tablet-landscape-up {
+			// Select every 6 elements, starting from position 1
+			// And make it take up 6 columns
+			> :global(:nth-child(6n + 1)) {
+				grid-column: span 6;
+			}
+			// Select every 6 elements, starting from position 2
+			// And make it take up 3 columns
+			> :global(:nth-child(6n + 2)) {
+				grid-column: span 3;
+			}
+			// Select every 6 elements, starting from position 3
+			// And make it take up 3 columns
+			> :global(:nth-child(6n + 3)) {
+				grid-column: span 3;
+			}
+			// Select every 6 elements, starting from position 4, 5 and 6
+			// And make it take up 2 columns
+			> :global(:nth-child(6n + 4)),
+			:global(:nth-child(6n + 5)),
+			:global(:nth-child(6n + 6)) {
+				grid-column: span 2;
+			}
+		}
+	}
+</style>


### PR DESCRIPTION
## Tag route
* Make each `Tag` in `+layout.svelte` of `(blog-article)` into a link. This link, `<a href="/tags/{tag}">{tag}</a>`, connects to a new route called `tag`. On this page, any blog post which contains the tag which was clicked on is displayed. In the example below, the tag `Performance` has been clicked and the blog posts which are tagged `Performance` are displayed.
<img width="1423" alt="Screenshot 2024-05-15 at 19 08 33" src="https://github.com/torrust/torrust-website/assets/95353365/dbe771cd-a5f8-488a-8a66-28231b25a6ac">

## Share button
* A new component called `ShareUrl.svelte` has been added to `singletons`. This component consists of a button which copies the url and has been placed beside the four other means of sharing the blog post. This component is separate from `ShareButton.svelte` as the functionality to copy the URL is distinct from the functionality for sharing the blog post on Facebook, LinkedIn, etc.
* When the button is clicked, a `setTimeout` in `onMount` changes the text of `Share` share icon to a green tick and text of `Link copied` for three seconds before reverting back to `Share`.

## Updated packages
* The following packages have been updated:
    * `eslint-plugin-svelte`
    * `sass`
    * `svelte`
    * `svelte-check`