### PR TITLE
Fix duplicate blog posts

### DIFF
--- a/src/lib/data/blog-posts/utils.ts
+++ b/src/lib/data/blog-posts/utils.ts
@@ -25,6 +25,7 @@ export const importPosts = (render = false) => {
 
 	const posts: BlogPost[] = [];
 	for (const path in imports) {
+		if (path.startsWith('/src/routes/v2')) continue;
 		const post = imports[path] as ImportedModule;
 		if (post) {
 			posts.push({


### PR DESCRIPTION
Fix duplicate blog posts. Blog posts are shown twice in the current version (v1) when they are added to the new version (v2).